### PR TITLE
fix: remove warning from Ansible 2.2

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,7 +1,14 @@
 ---
 
+- name: Get Gitlab repository installation script
+  get_url:
+    url: https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.deb.sh
+    dest: /tmp/gitlab-runner.script.deb.sh
+    mode: 0744
+
 - name: Install Gitlab repository
-  shell: curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.deb.sh | sudo bash
+  shell: bash /tmp/gitlab-runner.script.deb.sh
+  become: true
 
 - name: Install GitLab Runner
   apt:


### PR DESCRIPTION
This removes the warning when running ansible with this role:

     [WARNING]: Consider using get_url or uri module rather than running curl