### PR TITLE
debian: add possibility to fix package version number

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -3,7 +3,17 @@
 - name: Install Gitlab repository
   shell: curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.deb.sh | sudo bash
 
+- set_fact:
+    gitlab_runner_package_name: "gitlab-ci-multi-runner={{ gitlab_runner_package_version }}"
+    gitlab_runner_package_state: "present"
+  when: gitlab_runner_package_version is defined
+
+- set_fact:
+    gitlab_runner_package_name: "gitlab-ci-multi-runner"
+    gitlab_runner_package_state: "latest"
+  when: gitlab_runner_package_version is not defined
+
 - name: Install GitLab Runner
   apt:
-    name: gitlab-ci-multi-runner
-    state: present
+    name: "{{ gitlab_runner_package_name }}"
+    state: "{{ gitlab_runner_package_state }}"

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -6,4 +6,4 @@
 - name: Install GitLab Runner
   apt:
     name: gitlab-ci-multi-runner
-    state: latest
+    state: present


### PR DESCRIPTION
Hi,

We have noticed that this role updates the `gitlab-ci-multi-runner` binary automatically at each run of this role.

I though it was better to create a new task list or role for updates.

Indeed you don't alway expect the binary to be updated at each run of this role (especially when it's run automatically in a CI/CD fashion).

What do you think about this patch?