### PR TITLE
Fix concurrency auto-detection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 gitlab_runner_package_name: 'gitlab-ci-multi-runner'
 
 # Maximum number of jobs to run concurrently
-gitlab_runner_concurrent: '{{ ansible_processor_cores }}'
+gitlab_runner_concurrent: '{{ ansible_processor_vcpus }}'
 
 # GitLab coordinator URL
 gitlab_runner_coordinator_url: 'https://gitlab.com/ci'


### PR DESCRIPTION
Auto-detect runner concurrency based on total CPU threads (vcpus), instead of only processor cores. This accounts for both multiple cores and multiple processors.

For example, some virtual machines will detect as having multiple discrete processors (1 core each) instead of one processor with multiple cores. And some physical servers have 2 (or more) processor sockets.

See https://stackoverflow.com/questions/39539559/ansible-procesor-count-vs-processor-cores-vs-processor-vcpus