### PR TITLE
Fix registration check when in Ansible check-mode

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -3,6 +3,7 @@
   command: gitlab-runner list
   register: configured_runners
   changed_when: False
+  check_mode: no
 
 - name: Register runner to GitLab
   command: gitlab-runner register >


### PR DESCRIPTION
When running the playbook in `--check` mode, `gitlab-runner list` still needs to register a result to prevent an error on the following `when` clause.