### PR TITLE
Add limit option for specific runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Role Variables
 **Since Gitlab 10.x** The package name of `gitlab-ci-multi-runner` has been renamed to `gitlab-runner`. In order to install a version >= 10.x you will need to define this variable `gitlab_runner_package_name: gitlab-runner`.
 
 `gitlab_runner_concurrent`
-The maximum number of jobs to run concurrently.
+The maximum number of global jobs to run concurrently.
 Defaults to the number of processor cores.
 
 `gitlab_runner_registration_token`
@@ -33,6 +33,10 @@ Defaults to the hostname.
 `gitlab_runner_executor`
 The executor used by the runner.
 Defaults to `shell`.
+
+`gitlab_runner_concurrent_specific`
+The maximum number of jobs to run concurrently on this specific runner.
+Defaults to 0, simply means don't limit.
 
 `gitlab_runner_docker_image`
 The default Docker image to use. Required when executor is `docker`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # Change this variable value to 'gitlab-runner' for versions >= 10.x
 gitlab_runner_package_name: 'gitlab-ci-multi-runner'
 
-# Maximum number of jobs to run concurrently
+# Maximum number of global jobs to run concurrently
 gitlab_runner_concurrent: '{{ ansible_processor_vcpus }}'
 
 # GitLab coordinator URL
@@ -13,6 +13,8 @@ gitlab_runner_registration_token: ''
 gitlab_runner_description: '{{ ansible_hostname }}'
 # Runner executor
 gitlab_runner_executor: 'shell'
+# Maximum number of jobs to run concurrently on this specific runner
+gitlab_runner_concurrent_specific: '0'
 # Default Docker image
 gitlab_runner_docker_image: ''
 # Runner tags

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -13,6 +13,7 @@
     --description '{{ gitlab_runner_description }}'
     --tag-list '{{ gitlab_runner_tags | join(",") }}'
     --executor '{{ gitlab_runner_executor }}'
+    --limit '{{ gitlab_runner_concurrent_specific }}'
     --locked='{{gitlab_runner_locked}}'
     --docker-image '{{ gitlab_runner_docker_image }}'
     {% if gitlab_runner_docker_volumes is defined %}


### PR DESCRIPTION
When registering multiple runner on the same host, we may want to enforce a limit different than the global one.