### PR TITLE
Role variable name was incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Defaults to the hostname.
 The executor used by the runner.
 Defaults to `shell`.
 
-`gitlab_runner_concurrent_specific`
+`gitlab_runner_concurrent`
 The maximum number of jobs to run concurrently on this specific runner.
 Defaults to 0, simply means don't limit.
 


### PR DESCRIPTION
Couldn't figure out why this wasn't working and noticed the variable had a different name in the sources. :-)