### PR TITLE
Ensure credentials not stored in any log file or console output

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -38,3 +38,4 @@
     --cache-cache-shared '{{ gitlab_runner_cache_cache_shared }}'
     {% endif %}
   when: configured_runners.stderr.find('\n' + gitlab_runner_description) == -1
+  no_log: yes


### PR DESCRIPTION
The `gitlab-runner register` command may include secrets such as S3 secret keys, SSH passwords etc. which should not be logged or output to the console for security reasons.