### PR TITLE
Add creates to fix non-idempotent task Install Gitlab repository

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -8,6 +8,8 @@
 
 - name: Install Gitlab repository
   shell: bash /tmp/gitlab-runner.script.deb.sh
+  args:
+    creates: "/etc/apt/sources.list.d/runner_{{ gitlab_runner_package_name }}.list"
   become: true
 
 - set_fact:


### PR DESCRIPTION
Hi, I noticed that "Install Gitlab repository" task is not idempotent. Here's my fix.
Thanks, bye.

--domenico