### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -11,11 +11,10 @@
 
 - name: Install GitLab Runner dependencies
   yum:
-    name: '{{ item }}'
+    name:
+      - pygpgme
+      - yum-utils
     state: present
-  with_items:
-    - pygpgme
-    - yum-utils
 
 - name: Add GitLab Runner rpm repo
   template:


### PR DESCRIPTION
Fix
```
TASK [riemers.gitlab-runner : Install GitLab Runner dependencies] ****************************
[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is
deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item
}}"`, please use `name: ['pygpgme', 'yum-utils']` and remove the loop. This feature will be
removed in version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
```