### PR TITLE
Multiple runners, configurable runners and extra options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ install:
 script:
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  # Running tests
+  - ansible-playbook tests/test.yml -i tests/inventory
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -26,40 +26,8 @@ The GitLab registration token. If this is specified, a runner will be registered
 The GitLab coordinator URL.
 Defaults to `https://gitlab.com/ci`.
 
-`gitlab_runner_description`
-The description of the runner.
-Defaults to the hostname.
-
-`gitlab_runner_executor`
-The executor used by the runner.
-Defaults to `shell`.
-
-`gitlab_runner_concurrent_specific`
-The maximum number of jobs to run concurrently on this specific runner.
-Defaults to 0, simply means don't limit.
-
-`gitlab_runner_docker_image`
-The default Docker image to use. Required when executor is `docker`.
-
-`gitlab_runner_tags`
-The tags assigned to the runner,
-Defaults to an empty list.
-
-`gitlab_runner_cache_type`
-Variables to set s3 as a shared cache server. If set it requires variables listed below:
-`gitlab_runner_cache_s3_server_address`
-`gitlab_runner_cache_s3_access_key`
-`gitlab_runner_cache_s3_access_key`
-`gitlab_runner_cache_s3_bucket_name`
-`gitlab_runner_cache_s3_insecure`
-`gitlab_runner_cache_cache_shared`
-
-`gitlab_runner_extra_options`
-The extra options to the runner.
-For example:  
-gitlab_runner_extra_options: '--maximum-timeout=3600'
-
-See the [config for more options](https://github.com/riemers/ansible-gitlab-runner/blob/master/tasks/register-runner.yml)
+`gitlab_runner_runners`
+A list of gitlab runners to register & configure. Defaults to a single shell executor. See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file listing all possible options which you can be passed to a runner registration command.
 
 Example Playbook
 ----------------
@@ -75,12 +43,14 @@ Example Playbook
 Inside `vars/main.yml`
 ```yaml
 gitlab_runner_registration_token: 'HUzTMgnxk17YV8Rj8ucQ'
-gitlab_runner_description: 'Example GitLab Runner'
-gitlab_runner_tags:
-  - node
-  - ruby
-  - mysql
-gitlab_runner_docker_volumes:
-  - "/var/run/docker.sock:/var/run/docker.sock"
-  - "/cache"
+gitlab_runner_runners:
+  - name: 'Example Docker GitLab Runner'
+    executor: docker
+    tags:
+      - node
+      - ruby
+      - mysql
+    docker_volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/cache"
 ```

--- a/README.md
+++ b/README.md
@@ -53,4 +53,10 @@ gitlab_runner_runners:
     docker_volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "/cache"
+    extra_configs:
+      runners.docker:
+        memory: 512m
+        allowed_images: ["ruby:*", "python:*", "php:*"]
+      runners.docker.sysctls:
+        net.ipv4.ip_forward: "1"
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,31 +9,72 @@ gitlab_runner_concurrent: '{{ ansible_processor_vcpus }}'
 gitlab_runner_coordinator_url: 'https://gitlab.com/ci'
 # GitLab registration token
 gitlab_runner_registration_token: ''
-# Runner description
-gitlab_runner_description: '{{ ansible_hostname }}'
-# Runner executor
-gitlab_runner_executor: 'shell'
-# Maximum number of jobs to run concurrently on this specific runner
-gitlab_runner_concurrent_specific: '0'
-# Default Docker image
-gitlab_runner_docker_image: ''
-# Runner tags
-gitlab_runner_tags: []
-# Docker privileged mode
-gitlab_runner_docker_privileged: false
-# Runner SSH user
-gitlab_runner_ssh_user: ''
-# Runner SSH host
-gitlab_runner_ssh_host: ''
-# Runner SSH port
-gitlab_runner_ssh_port: ''
-# Runner SSH password
-gitlab_runner_ssh_password: ''
-# Runner SSH identity file
-gitlab_runner_ssh_identity_file: ''
-# Runner Locked
-gitlab_runner_locked: 'false'
-# Custom environment variables injected to build environment
-gitlab_runner_env_vars: []
-# Custom parameters for gitlab-runner register command
-gitlab_runner_extra_options: ''
+
+# A list of runners to register and configure
+gitlab_runner_runners:
+    # The identifier of the runner.
+  - name: '{{ ansible_hostname }}'
+    # set to 'absent' if you want to delete the runner. Defaults to 'present'.
+    state: present
+    # The executor used by the runner.
+    executor: 'shell'
+    # Maximum number of jobs to run concurrently on this specific runner.
+    # Defaults to 0, simply means don't limit.
+    concurrent_specific: '0'
+    # The default Docker image to use. Required when executor is `docker`.
+    docker_image: ''
+    # The tags assigned to the runner.
+    tags: []
+    # Indicates whether this runner can pick jobs without tags.
+    run_untagged: true
+    # Docker privileged mode
+    docker_privileged: false
+    # Runner Locked. When a runner is locked, it cannot be assigned to other projects
+    locked: 'false'
+    # Custom environment variables injected to registration command
+    env_vars: []
+    #
+    # Runner SSH user
+    # ssh_user: ''
+    #
+    # Runner SSH host
+    # ssh_host: ''
+    #
+    # Runner SSH port
+    # ssh_port: ''
+    #
+    # Runner SSH password
+    # ssh_password: ''
+    #
+    # Runner SSH identity file
+    # ssh_identity_file: ''
+    #
+    # Cache type
+    # cache_type: 's3'
+    #
+    # Cache path
+    # cache_path: prefix/key
+    #
+    # Cache shared
+    # cache_shared: false
+    #
+    # Cache S3 server address
+    # cache_s3_server_address: "s3.amazonaws.com"
+    #
+    # Cache S3 access key
+    # cache_s3_access_key: "AMAZON_S3_ACCESS_KEY"
+    #
+    # Cache S3 secret key
+    # cache_s3_secret_key: "AMAZON_S3_SECRET_KEY"
+    #
+    # Cache S3 bucket name
+    # cache_s3_bucket_name: "my-bucket"
+    #
+    # Cache S3 bucket location
+    # cache_s3_bucket_location: "eu-west-1"
+    #
+    # Cache S3 insecure
+    # cache_s3_insecure: false
+    #
+    # Extra registration option
+    # extra_registration_option: '--maximum-timeout=3600'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,3 +78,15 @@ gitlab_runner_runners:
     #
     # Extra registration option
     # extra_registration_option: '--maximum-timeout=3600'
+    #
+    # Extra configuration options to change in the config.toml file
+    # This parameter is a dictionnary where the first level keys are TOML section names
+    # Full list of configuration are available on Gitlab Runner documentation:
+    # See https://docs.gitlab.com/runner/configuration/advanced-configuration.html
+    #
+    # extra_configs:
+    #   runners.docker:
+    #     memory: 512m
+    #     allowed_images: ["ruby:*", "python:*", "php:*"]
+    #   runners.docker.sysctls:
+    #     net.ipv4.ip_forward: "1"

--- a/files/gitlab-runner-wrapper.sh
+++ b/files/gitlab-runner-wrapper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE=${1} /usr/bin/gitlab-runner verify

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: reload_gitlab_runner
+  service: name=gitlab-runner state=reloaded
+  become: yes
+
 - name: restart_gitlab_runner
   service: name=gitlab-runner state=restarted
   become: yes

--- a/tasks/config-runner.yml
+++ b/tasks/config-runner.yml
@@ -1,0 +1,36 @@
+---
+- name: Create temporary file
+  tempfile:
+    state: file
+    path: "{{ temp_runner_config_dir.path }}"
+    prefix: "gitlab-runner.{{ runner_config_index }}."
+  register: temp_runner_config
+  check_mode: no
+  changed_when: false
+
+- name: Isolate runner configuration
+  copy:
+    dest: "{{ temp_runner_config.path }}"
+    content: "{{ runner_config }}"
+  check_mode: no
+  changed_when: false
+
+- include_tasks: update-config-runner.yml
+  when:
+    - ('name = "'+gitlab_runner.name+'"') in runner_config
+    - gitlab_runner.state|default('present') == 'present'
+  loop: "{{ gitlab_runner_runners }}"
+  loop_control:
+    index_var: gitlab_runner_index
+    loop_var: gitlab_runner
+
+- name: Remove runner config
+  file:
+    path: "{{ temp_runner_config.path }}"
+    state: absent
+  when:
+    - ('name = "'+gitlab_runner.name+'"') in runner_config
+    - gitlab_runner.state|default('present') == 'absent'
+  loop: "{{ gitlab_runner_runners }}"
+  loop_control:
+    loop_var: gitlab_runner

--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -1,0 +1,36 @@
+---
+- name: Get existing config
+  slurp:
+    src: /etc/gitlab-runner/config.toml
+  register: runner_config_file
+
+- set_fact:
+    runner_configs: "{{ (runner_config_file['content'] | b64decode).split('[[runners]]\n') }}"
+
+- name: Create temporary directory
+  tempfile:
+    state: directory
+    suffix: gitlab-runner-config
+  register: temp_runner_config_dir
+  check_mode: no
+  changed_when: false
+
+- include_tasks: config-runner.yml
+  loop: "{{ runner_configs }}"
+  loop_control:
+    index_var: runner_config_index
+    loop_var: runner_config
+
+- copy:
+    src: gitlab-runner-wrapper.sh
+    dest: /tmp/gitlab-runner-wrapper.sh
+    mode: 0700
+  become: true
+
+- assemble:
+    src: "{{ temp_runner_config_dir.path }}"
+    dest: /etc/gitlab-runner/config.toml
+    backup: yes
+    validate: "/tmp/gitlab-runner-wrapper.sh %s"
+    mode: 0600
+  become: true

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -7,13 +7,3 @@
     state: present
     backrefs: yes
   notify: restart_gitlab_runner
-
-- name: Set docker privileged option
-  lineinfile:
-    dest: /etc/gitlab-runner/config.toml
-    regexp: '^(\s*)privileged ='
-    line: '\1privileged = {{ gitlab_runner_docker_privileged | lower}}'
-    state: present
-    backrefs: yes
-  notify: restart_gitlab_runner
-

--- a/tasks/line-config-runner.yml
+++ b/tasks/line-config-runner.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure section exists
+  lineinfile:
+    path: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)\[{{ section|regex_escape }}\]$'
+    line: '{{ "  " * (section.split(".")|length -1) }}[{{ section }}]'
+
+- name: Modify existing line
+  lineinfile:
+    path: "{{ temp_runner_config.path }}"
+    insertafter: '\s+\[{{ section | regex_escape }}\]'
+    regexp: '^(\s*){{ line|regex_escape }} ='
+    line: '{{ "  " * (section.split(".")|length) }}{{ line }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
+  register: modified_config_line

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,15 @@
 - name: Set global options
   import_tasks: global-setup.yml
 
+- name: List configured runners
+  command: gitlab-runner list
+  register: configured_runners
+  changed_when: False
+  check_mode: no
+
 - name: Register GitLab Runner
-  import_tasks: register-runner.yml
+  include_tasks: register-runner.yml
   when: gitlab_runner_registration_token != ''
+  loop: "{{ gitlab_runner_runners }}"
+  loop_control:
+    loop_var: gitlab_runner

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,3 +22,6 @@
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     loop_var: gitlab_runner
+
+- name: Configure GitLab Runner
+  import_tasks: config-runners.yml

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -1,47 +1,52 @@
 ---
-- name: List configured runners
-  command: gitlab-runner list
-  register: configured_runners
-  changed_when: False
-  check_mode: no
-
 - name: Register runner to GitLab
   command: >
     gitlab-runner register
     --non-interactive
     --url '{{ gitlab_runner_coordinator_url }}'
     --registration-token '{{ gitlab_runner_registration_token }}'
-    --description '{{ gitlab_runner_description }}'
-    --tag-list '{{ gitlab_runner_tags | join(",") }}'
-    --executor '{{ gitlab_runner_executor }}'
-    --limit '{{ gitlab_runner_concurrent_specific }}'
-    --locked='{{gitlab_runner_locked}}'
-    {% for env_var in gitlab_runner_env_vars %}
+    --description '{{ gitlab_runner.name|default(ansible_hostname) }}'
+    --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
+    {% if gitlab_runner.run_untagged|default(true) %}
+    --run-untagged
+    {% endif %}
+    --executor '{{ gitlab_runner.executor|default("shell") }}'
+    --limit '{{ gitlab_runner.concurrent_specific|default(0) }}'
+    --locked='{{ gitlab_runner.locked|default(false) }}'
+    {% for env_var in gitlab_runner.env_vars|default([]) %}
     --env '{{ env_var }}'
     {% endfor %}
-    --docker-image '{{ gitlab_runner_docker_image }}'
-    {% if gitlab_runner_docker_privileged %}
+    --docker-image '{{ gitlab_runner.docker_image|default("") }}'
+    {% if gitlab_runner.docker_privileged|default(false) %}
     --docker-privileged
     {% endif %}
-    {% for volume in gitlab_runner_docker_volumes | default([]) %}
+    {% for volume in gitlab_runner.docker_volumes | default([]) %}
     --docker-volumes "{{ volume }}"
     {% endfor %}
-    --ssh-user '{{ gitlab_runner_ssh_user }}'
-    --ssh-host '{{ gitlab_runner_ssh_host }}'
-    --ssh-port '{{ gitlab_runner_ssh_port }}'
-    --ssh-password '{{ gitlab_runner_ssh_password }}'
-    --ssh-identity-file '{{ gitlab_runner_ssh_identity_file }}'
-    {% if gitlab_runner_cache_type is defined %}
-    --cache-type '{{ gitlab_runner_cache_type }}'
-    --cache-s3-server-address '{{ gitlab_runner_cache_s3_server_address }}'
-    --cache-s3-access-key '{{ gitlab_runner_cache_s3_access_key }}'
-    --cache-s3-secret-key '{{ gitlab_runner_cache_s3_secret_key }}'
-    --cache-s3-bucket-name '{{ gitlab_runner_cache_s3_bucket_name }}'
-    --cache-s3-insecure '{{ gitlab_runner_cache_s3_insecure }}'
-    --cache-cache-shared '{{ gitlab_runner_cache_cache_shared }}'
+    --ssh-user '{{ gitlab_runner.ssh_user|default("") }}'
+    --ssh-host '{{ gitlab_runner.ssh_host|default("") }}'
+    --ssh-port '{{ gitlab_runner.ssh_port|default("") }}'
+    --ssh-password '{{ gitlab_runner.ssh_password|default("") }}'
+    --ssh-identity-file '{{ gitlab_runner.ssh_identity_file|default("") }}'
+    {% if gitlab_runner.cache_type is defined %}
+    --cache-type '{{ gitlab_runner.cache_type }}'
+    --cache-shared '{{ gitlab_runner.cache_shared }}'
+    {% if gitlab_runner.cache_path is defined %}
+    --cache-path '{{ gitlab_runner.cache_path }}'
     {% endif %}
-    {% if gitlab_runner_extra_options is defined %}
-    '{{ gitlab_runner_extra_options }}'
+    {% if gitlab_runner.cache_s3_server_address is defined %}
+    --cache-s3-server-address '{{ gitlab_runner.cache_s3_server_address }}'
+    --cache-s3-access-key '{{ gitlab_runner.cache_s3_access_key }}'
+    --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
     {% endif %}
-  when: configured_runners.stderr.find('\n' + gitlab_runner_description) == -1
-  no_log: yes
+    --cache-s3-bucket-name '{{ gitlab_runner.cache_s3_bucket_name }}'
+    --cache-s3-bucket-location '{{ gitlab_runner.cache_s3_bucket_location }}'
+    --cache-s3-insecure '{{ gitlab_runner.cache_s3_insecure }}'
+    {% endif %}
+    {% if gitlab_runner.extra_registration_option is defined %}
+    {{ gitlab_runner.extra_registration_option }}
+    {% endif %}
+  when:
+    - configured_runners.stderr.find('\n' + gitlab_runner.name) == -1
+    - gitlab_runner.state|default('present') == 'present'
+  no_log: true

--- a/tasks/section-config-runner.yml
+++ b/tasks/section-config-runner.yml
@@ -1,0 +1,5 @@
+---
+- include: line-config-runner.yml
+  loop: "{{ gitlab_runner.extra_configs[section] | list }}"
+  loop_control:
+    loop_var: line

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -134,3 +134,11 @@
     backrefs: yes
   check_mode: no
   notify: reload_gitlab_runner
+
+- include: section-config-runner.yml
+  loop: "{{ gitlab_runner.extra_configs|list }}"
+  loop_control:
+    loop_var: section
+  when:
+    - gitlab_runner.extra_configs is defined
+    - gitlab_runner.extra_configs|list|length > 0

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -1,0 +1,136 @@
+---
+- name: Create temporary file
+  tempfile:
+    state: file
+    path: "{{ temp_runner_config_dir.path }}"
+    prefix: "gitlab-runner.{{ gitlab_runner_index }}{{ runner_config_index }}."
+  register: temp_runner_config_keyword
+  check_mode: no
+  changed_when: false
+
+- name: Isolate runner configuration
+  copy:
+    dest: "{{ temp_runner_config_keyword.path }}"
+    content: "[[runners]]"
+  check_mode: no
+  changed_when: false
+
+- name: Set concurrent limit option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)limit ='
+    line: '\1limit = {{ gitlab_runner.concurrent_specific|default(0) }}'
+    state: present
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set coordinator URL
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)url ='
+    line: '\1url = {{ gitlab_runner_coordinator_url | to_json }}'
+    state: present
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set runner executor option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)executor ='
+    line: '\1executor = {{ gitlab_runner.executor|default("shell") | to_json}}'
+    state: present
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set runner docker image option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)image ='
+    line: '\1image = {{ gitlab_runner.docker_image|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.docker_image is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set docker privileged option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)privileged ='
+    line: '\1privileged = {{ gitlab_runner.docker_privileged|default(false) | lower }}'
+    state: "{{ 'present' if gitlab_runner.docker_privileged is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set docker volumes option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)volumes ='
+    line: '\1volumes = {{ gitlab_runner.docker_volumes|default([])|to_json }}'
+    state: "{{ 'present' if gitlab_runner.docker_volumes is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set cache type option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)Type ='
+    line: '\1Type = {{ gitlab_runner.cache_type|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.cache_type is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set cache path option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)Path ='
+    line: '\1Path = {{ gitlab_runner.cache_path|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.cache_path is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set cache shared option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)Shared ='
+    line: '\1Shared = {{ gitlab_runner.cache_shared|default("") | lower }}'
+    state: "{{ 'present' if gitlab_runner.cache_shared is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set cache s3 bucket name option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)BucketName ='
+    line: '\1BucketName = {{ gitlab_runner.cache_s3_bucket_name|default("")  | to_json }}'
+    state: "{{ 'present' if gitlab_runner.cache_s3_bucket_name is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set cache s3 bucket location option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)BucketLocation ='
+    line: '\1BucketLocation = {{ gitlab_runner.cache_s3_bucket_location|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.cache_s3_bucket_location is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner
+
+- name: Set cache s3 insecure option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^(\s*)Insecure ='
+    line: '\1Insecure = {{ gitlab_runner.cache_s3_insecure|default("") | lower }}'
+    state: "{{ 'present' if gitlab_runner.cache_s3_insecure is defined else 'absent' }}"
+    backrefs: yes
+  check_mode: no
+  notify: reload_gitlab_runner

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,1 @@
-localhost
+localhost ansible_connection=local

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,21 @@
 ---
 - hosts: localhost
   remote_user: root
+  become: true
+  vars:
+    gitlab_runner_runners:
+      - name: 'vagrant-shell'
+        executor: shell
+        tags:
+          - node
+          - ruby
+          - mysql
+      - name: 'vagrant-docker'
+        executor: docker
+        docker_image: 'docker:stable'
+        tags:
+          - node
+          - ruby
+          - mysql
   roles:
     - ansible-gitlab-runner


### PR DESCRIPTION
This PR is quite a big change but was necessary for us at [`Fretlink`](https://github.com/fretlink/).

The 3 main changes are:
- allows to register multiple runners on the same instance
- allows to **remove** an existing runner with the `gitlab_runner_runners[i].state` value (`present` or `absent`)
- allows to change configuration for a runner (after registration) fixing #17 
- allow extra TOML options to be configured 
  Adds a `extra_configs` key to a runner's variables to
allow custom TOML sections to be changed/added. 
  The operation is **non-destructive**. Meaning that any existing
configuration option will **not** be removed if they already exist in
the `/etc/gitlab-runner/config.toml` file.
