### PR TITLE
Make the registration token runner specific.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,12 @@ Role Variables
 The maximum number of global jobs to run concurrently.
 Defaults to the number of processor cores.
 
-`gitlab_runner_registration_token`
-The GitLab registration token. If this is specified, a runner will be registered to a GitLab server.
-
 `gitlab_runner_coordinator_url`
 The GitLab coordinator URL.
 Defaults to `https://gitlab.com/ci`.
 
 `gitlab_runner_runners`
-A list of gitlab runners to register & configure. Defaults to a single shell executor. See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file listing all possible options which you can be passed to a runner registration command.
+A list of gitlab runners to register & configure. Defaults to a single shell executor. See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file for a listing of all possible options which can be passed to a runner registration command.
 
 Example Playbook
 ----------------
@@ -42,10 +39,10 @@ Example Playbook
 
 Inside `vars/main.yml`
 ```yaml
-gitlab_runner_registration_token: 'HUzTMgnxk17YV8Rj8ucQ'
 gitlab_runner_runners:
-  - name: 'Example Docker GitLab Runner'
+  - name: 'Runner for GitLab Group 1'
     executor: docker
+    registration_token: 'HUzTMgnxk17YV8Rj8ucQ'
     tags:
       - node
       - ruby
@@ -57,6 +54,18 @@ gitlab_runner_runners:
       runners.docker:
         memory: 512m
         allowed_images: ["ruby:*", "python:*", "php:*"]
-      runners.docker.sysctls:
-        net.ipv4.ip_forward: "1"
+  - name: 'Runner for GitLab Group 2'
+    executor: docker
+    registration_token: 'wootiSha6aeWoo9yungi'
+    tags:
+      - node
+      - ruby
+      - mysql
+    docker_volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/cache"
+    extra_configs:
+      runners.docker:
+        memory: 512m
+        allowed_images: ["ruby:*", "python:*", "php:*"]
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,6 @@ gitlab_runner_concurrent: '{{ ansible_processor_vcpus }}'
 
 # GitLab coordinator URL
 gitlab_runner_coordinator_url: 'https://gitlab.com/ci'
-# GitLab registration token
-gitlab_runner_registration_token: ''
 
 # A list of runners to register and configure
 gitlab_runner_runners:
@@ -16,6 +14,8 @@ gitlab_runner_runners:
   - name: '{{ ansible_hostname }}'
     # set to 'absent' if you want to delete the runner. Defaults to 'present'.
     state: present
+    # GitLab registration token
+    registration_token: ''
     # The executor used by the runner.
     executor: 'shell'
     # Maximum number of jobs to run concurrently on this specific runner.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Register GitLab Runner
   include_tasks: register-runner.yml
-  when: gitlab_runner_registration_token != ''
+  when: gitlab_runner.registration_token != ''
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     index_var: gitlab_runner_index

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -4,7 +4,7 @@
     gitlab-runner register
     --non-interactive
     --url '{{ gitlab_runner_coordinator_url }}'
-    --registration-token '{{ gitlab_runner_registration_token }}'
+    --registration-token '{{ gitlab_runner.registration_token }}'
     --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
     --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
     {% if gitlab_runner.run_untagged|default(true) %}


### PR DESCRIPTION
This PR enables you to register different runners for different GitLab groups (each GitLab group has it's own runner registration token).

Without this change you are not able to register group runners for more than one GitLab group when using this role for a server. Note: We are hosting our repositories at gitlab.com but want to use our own runners for CI builds. That is, we are not running our own GitLab instance. Under such circumstances there is no such thing as a global `shared-Runner token` (see e.g. [here](https://docs.gitlab.com/ee/ci/runners/#registering-a-shared-runner)).

Also remove the `net.ipv4.ip_forward` docker option from the example in the README file because it fails.