### PR TITLE
Add sentry dsn to global config if it's defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The GitLab registration token. If this is specified, a runner will be registered
 The GitLab coordinator URL.
 Defaults to `https://gitlab.com/ci`.
 
+`gitlab_runner_sentry_dsn`
+Enable tracking of all system level errors to Sentry
+
 `gitlab_runner_runners`
 A list of gitlab runners to register & configure. Defaults to a single shell executor. See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file listing all possible options which you can be passed to a runner registration command.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@ gitlab_runner_coordinator_url: 'https://gitlab.com/ci'
 # GitLab registration token
 gitlab_runner_registration_token: ''
 
+gitlab_runner_sentry_dsn: ''
+
 # A list of runners to register and configure
 gitlab_runner_runners:
     # The identifier of the runner.

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -12,9 +12,9 @@
   lineinfile:
     dest: /etc/gitlab-runner/config.toml
     regexp: '^sentry_dsn ='
-    line: 'sentry_dsn = "{{ sentry_dsn }}"'
+    line: 'sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"'
     insertafter: '\s*concurrent.*'
     state: present
-  when: sentry_dsn is defined
+  when: gitlab_runner_sentry_dsn != ""
   notify: restart_gitlab_runner
 - 

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -7,3 +7,14 @@
     state: present
     backrefs: yes
   notify: restart_gitlab_runner
+
+- name: Add sentry dsn to config
+  lineinfile:
+    dest: /etc/gitlab-runner/config.toml
+    regexp: '^sentry_dsn ='
+    line: 'sentry_dsn = "{{ sentry_dsn }}"'
+    insertafter: '\s*concurrent.*'
+    state: present
+  when: sentry_dsn is defined
+  notify: restart_gitlab_runner
+- 


### PR DESCRIPTION
We use sentry in several of our projects. According to the [advanced config docs](https://docs.gitlab.com/runner/configuration/advanced-configuration.html), it is possible to set the dsn in the global config.

