### PR TITLE
fix boolean parameters

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -30,7 +30,9 @@
     --ssh-identity-file '{{ gitlab_runner.ssh_identity_file|default("") }}'
     {% if gitlab_runner.cache_type is defined %}
     --cache-type '{{ gitlab_runner.cache_type }}'
-    --cache-shared '{{ gitlab_runner.cache_shared }}'
+    {% if gitlab_runner.cache_shared == true %}
+    --cache-shared
+    {% endif %}
     {% if gitlab_runner.cache_path is defined %}
     --cache-path '{{ gitlab_runner.cache_path }}'
     {% endif %}
@@ -41,7 +43,9 @@
     {% endif %}
     --cache-s3-bucket-name '{{ gitlab_runner.cache_s3_bucket_name }}'
     --cache-s3-bucket-location '{{ gitlab_runner.cache_s3_bucket_location }}'
-    --cache-s3-insecure '{{ gitlab_runner.cache_s3_insecure }}'
+    {% if gitlab_runner.cache_s3_insecure == true %}
+    --cache-s3-insecure
+    {% endif %}
     {% endif %}
     {% if gitlab_runner.extra_registration_option is defined %}
     {{ gitlab_runner.extra_registration_option }}


### PR DESCRIPTION
warning are generated when trying to configure 
  `cache_shared: true`
in yml file:
```
"stderr": "time=\"2019-06-10T07:58:21-07:00\" level=warning msg=\"boolean parameters must be passed in the command line with --cache-shared=true\"\ntime=\"2019-06-10T07:58:21-07:00\" level=warning msg=\"parameters after this may be ignored\"\n 
```

this fix makes `cache_shared` and `cache_s3_insecure` working correctly as boolean parameters