### PR TITLE
Fix config bugs and add /tmp dir var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,3 +92,5 @@ gitlab_runner_runners:
     #     allowed_images: ["ruby:*", "python:*", "php:*"]
     #   runners.docker.sysctls:
     #     net.ipv4.ip_forward: "1"
+
+gitlab_runner_temp_dir: /tmp

--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -23,7 +23,7 @@
 
 - copy:
     src: gitlab-runner-wrapper.sh
-    dest: /tmp/gitlab-runner-wrapper.sh
+    dest: "{{ gitlab_runner_temp_dir|default('/tmp', true) }}/gitlab-runner-wrapper.sh"
     mode: 0700
   become: true
 
@@ -31,6 +31,6 @@
     src: "{{ temp_runner_config_dir.path }}"
     dest: /etc/gitlab-runner/config.toml
     backup: yes
-    validate: "/tmp/gitlab-runner-wrapper.sh %s"
+    validate: "{{ gitlab_runner_temp_dir|default('/tmp', true) }}/gitlab-runner-wrapper.sh %s"
     mode: 0600
   become: true

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -31,7 +31,7 @@
     {% if gitlab_runner.cache_type is defined %}
     --cache-type '{{ gitlab_runner.cache_type }}'
     {% endif %}
-    {% if gitlab_runner.cache_shared == true %}
+    {% if gitlab_runner.cache_shared|default(false) %}
     --cache-shared
     {% endif %}
     {% if gitlab_runner.cache_path is defined %}
@@ -48,7 +48,7 @@
     {% if gitlab_runner.cache_s3_bucket_location is defined %}
     --cache-s3-bucket-location '{{ gitlab_runner.cache_s3_bucket_location }}'
     {% endif %}
-    {% if gitlab_runner.cache_s3_insecure == true %}
+    {% if gitlab_runner.cache_s3_insecure|default(false) %}
     --cache-s3-insecure
     {% endif %}
     {% if gitlab_runner.extra_registration_option is defined %}


### PR DESCRIPTION
A couple of runner configuration values would fail if they were not set since the jinja was assuming they exist.

Also I made `/tmp` for the `gitlab-runner-wrapper.sh` script configurable since some systems disable executing on `/tmp` for security purposes, atleast this way it can be configured to something else by the user.