### PR TITLE
Re-insert `[[runners]]` separator during assembly instead of manually

### DIFF
--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -30,6 +30,7 @@
 - assemble:
     src: "{{ temp_runner_config_dir.path }}"
     dest: /etc/gitlab-runner/config.toml
+    delimiter: '[[runners]]\n'
     backup: yes
     validate: "{{ gitlab_runner_temp_dir|default('/tmp', true) }}/gitlab-runner-wrapper.sh %s"
     mode: 0600

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -1,20 +1,4 @@
 ---
-- name: Create temporary file
-  tempfile:
-    state: file
-    path: "{{ temp_runner_config_dir.path }}"
-    prefix: "gitlab-runner.{{ gitlab_runner_index }}{{ runner_config_index }}."
-  register: temp_runner_config_keyword
-  check_mode: no
-  changed_when: false
-
-- name: Isolate runner configuration
-  copy:
-    dest: "{{ temp_runner_config_keyword.path }}"
-    content: "[[runners]]"
-  check_mode: no
-  changed_when: false
-
 - name: Set concurrent limit option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"


### PR DESCRIPTION
Fix #55