### PR TITLE
Ensure config.toml exists

### DIFF
--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Ensure config.toml exists
+  file:
+    path: /etc/gitlab-runner/config.toml
+    state: touch
+    modification_time: preserve
+    access_time: preserve
+
 - name: Set concurrent option
   lineinfile:
     dest: /etc/gitlab-runner/config.toml


### PR DESCRIPTION
The merge request adds a stage to the playbook that confirms that the `/etc/gitlab-runner/config.toml` file is present.  If it is absent, a blank file is created.  If it is already present, nothing happens.

See discussion on #55 

## To test

+ Delete `/etc/gitlab-runner/config.toml` from target machine and run playbook.  File should be created.
+ Run playbook again.  Task should return green OK.