### PR TITLE
config: allow environment field to be updated after registration

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -21,6 +21,17 @@
   check_mode: no
   notify: restart_gitlab_runner
 
+- name: Set environment option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*environment ='
+    line: '  environment = {{ gitlab_runner.env_vars|default([]) | to_json }}'
+    state: present
+    insertafter: '^\s*url='
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
 - name: Set runner executor option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"


### PR DESCRIPTION
For now the extra `env_vars` passed in the role was only used at
registration step of the runner. This commit allows to *update* the
`environment` field of an existing runner configuration.