### PR TITLE
Force variable to be a string before checking its length

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Register GitLab Runner
   include_tasks: register-runner.yml
-  when: gitlab_runner_registration_token | length > 0  # Ensure value is set
+  when: gitlab_runner_registration_token | string | length > 0  # Ensure value is set
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     index_var: gitlab_runner_index


### PR DESCRIPTION
Otherwise the check produces an error when the token has been encrypted with ansible vault.

Resolves issue #67 