### PR TITLE
Add macOS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 ---
-language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+jobs:
+  include:
+    - os: linux
+      python: "2.7"
+      language: python
+      addons:
+        apt:
+          packages:
+            - python-pip
+    - os: osx
+      osx_image: xcode10.3
+      # See https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-422830059
+      #language: python
+      language: generic
 
 install:
   # Install ansible
@@ -27,5 +31,5 @@ script:
   # Running tests
   - ansible-playbook tests/test.yml -i tests/inventory
 
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+#notifications:
+#  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,13 @@
 ---
 # Change this variable value to 'gitlab-runner' for versions >= 10.x
-gitlab_runner_package_name: 'gitlab-ci-multi-runner'
+gitlab_runner_package_name: 'gitlab-runner'
+
+gitlab_runner_config_file_location: "{{ ansible_env.HOME }}/.gitlab-runner"
+
+# Overridden based on platform
+gitlab_runner_config_file: "/etc/gitlab-runner/config.toml"
+
+gitlab_runner_executable: "{{ gitlab_runner_package_name }}"
 
 # Maximum number of global jobs to run concurrently
 gitlab_runner_concurrent: '{{ ansible_processor_vcpus }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,14 @@ gitlab_runner_package_name: 'gitlab-runner'
 
 gitlab_runner_config_file_location: "{{ ansible_env.HOME }}/.gitlab-runner"
 
+# gitlab_runner_package_version for version pinning on debian/redhat
+# The following are for version pinning on MacOSX
+gitlab_runner_wanted_version: latest
+
+# These two variable should not be modified usually as they depend on the gitlab_runner_wanted_version variable
+gitlab_runner_wanted_tag: "{{ 'latest' if gitlab_runner_wanted_version == 'latest' else ('v' + gitlab_runner_wanted_version) }}"
+gitlab_runner_download_url: 'https://gitlab-runner-downloads.s3.amazonaws.com/{{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-darwin-amd64'
+
 # Overridden based on platform
 gitlab_runner_config_file: "/etc/gitlab-runner/config.toml"
 

--- a/files/gitlab-runner-wrapper-macos.sh
+++ b/files/gitlab-runner-wrapper-macos.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE=${1} /usr/local/bin/gitlab-runner verify

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,12 @@
 ---
-
+# non macOS
 - name: restart_gitlab_runner
   service: name=gitlab-runner state=restarted
   become: yes
+  when: ansible_os_family != 'Darwin'
+
+# macOS
+- name: restart_gitlab_runner_macos
+  command: "{{ gitlab_runner_executable }} restart"
+  become: yes
+  when: ansible_os_family == 'Darwin'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
-  author: Erik-jan Riemers
-  description: GitLab Runner
+  author: Gastrofix
+  description: GitLab Runner with Mac OS support (based on Erik-jan Riemers role)
   license: MIT
   min_ansible_version: 2.0
   platforms:
@@ -14,6 +14,9 @@ galaxy_info:
   - name: Debian
     version:
     - all
+  - name: MacOSX
+    versions:
+      - all
   galaxy_tags:
     - gitlab
     - runner

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
-  author: Gastrofix
-  description: GitLab Runner with Mac OS support (based on Erik-jan Riemers role)
+  author: Erik-jan Riemers
+  description: GitLab Runner
   license: MIT
   min_ansible_version: 2.0
   platforms:

--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get existing config.toml
   slurp:
-    src: /etc/gitlab-runner/config.toml
+    src: "{{ gitlab_runner_config_file }}"
   register: runner_config_file
   become: true
 
@@ -26,7 +26,7 @@
 
 - name: Copy gitlab-runner-wrapper.sh
   copy:
-    src: gitlab-runner-wrapper.sh
+    src: "{{ gitlab_wrapper_script_name }}"
     dest: "{{ gitlab_runner_temp_dir|default('/tmp', true) }}/gitlab-runner-wrapper.sh"
     mode: 0700
   become: true
@@ -34,7 +34,7 @@
 - name: Assemble new config.toml
   assemble:
     src: "{{ temp_runner_config_dir.path }}"
-    dest: /etc/gitlab-runner/config.toml
+    dest: "{{ gitlab_runner_config_file }}"
     delimiter: '[[runners]]\n'
     backup: yes
     validate: "{{ gitlab_runner_temp_dir|default('/tmp', true) }}/gitlab-runner-wrapper.sh %s"

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -1,7 +1,13 @@
 ---
+- name: Create .gitlab-runner dir
+  file:
+    path: "{{ gitlab_runner_config_file_location }}"
+    state: directory
+    mode: '0755'
+
 - name: Ensure config.toml exists
   file:
-    path: /etc/gitlab-runner/config.toml
+    path: "{{ gitlab_runner_config_file }}"
     state: touch
     modification_time: preserve
     access_time: preserve
@@ -9,21 +15,25 @@
 
 - name: Set concurrent option
   lineinfile:
-    dest: /etc/gitlab-runner/config.toml
+    dest: "{{ gitlab_runner_config_file }}"
     regexp: '^(\s*)concurrent ='
     line: '\1concurrent = {{ gitlab_runner_concurrent }}'
     state: present
     backrefs: yes
-  notify: restart_gitlab_runner
   become: true
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
 
 - name: Add sentry dsn to config
   lineinfile:
-    dest: /etc/gitlab-runner/config.toml
+    dest: "{{ gitlab_runner_config_file }}"
     regexp: '^sentry_dsn ='
     line: 'sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"'
     insertafter: '\s*concurrent.*'
     state: present
   when: gitlab_runner_sentry_dsn | length > 0  # Ensure value is set
-  notify: restart_gitlab_runner
   become: true
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos

--- a/tasks/install-macos.yml
+++ b/tasks/install-macos.yml
@@ -9,13 +9,24 @@
     set_fact:
       gitlab_runner_exists: "{{ gitlab_runner_exists.stat.exists }}"
 
+  - name: (MacOS) Get existing version
+    shell: "{{ gitlab_runner_executable }} --version | awk '/Version: ([\\d\\.]*)/{print $2}'"
+    register: existing_version_shell
+    failed_when: no
+    check_mode: no
+    changed_when: no
+
+  - name: (MacOS) Set fact -> gitlab_runner_existing_version
+    set_fact:
+      gitlab_runner_existing_version: "{{ existing_version_shell.stdout if existing_version_shell.rc == 0 else '0' }}"
+
 - name: (MacOS) INSTALL GitLab Runner for macOS
   block:
     - name: (MacOS) Download GitLab Runner
       get_url:
-        url: https://gitlab-runner-downloads.s3.amazonaws.com/latest/binaries/gitlab-runner-darwin-amd64
+        url: "{{ gitlab_runner_download_url }}"
         dest: "{{ gitlab_runner_executable }}"
-        validate_certs: no
+        force: yes
 
     - name: (MacOS) Setting Permissions for gitlab-runner executable
       file:
@@ -39,9 +50,9 @@
 
     - name: (MacOS) Download GitLab Runner
       get_url:
-        url: https://gitlab-runner-downloads.s3.amazonaws.com/latest/binaries/gitlab-runner-darwin-amd64
+        url: "{{ gitlab_runner_download_url }}"
         dest: "{{ gitlab_runner_executable }}"
-        validate_certs: no
+        force: yes
 
     - name: (MacOS) Setting Permissions for gitlab-runner executable
       file:
@@ -53,4 +64,6 @@
 
     - name: (MacOS) Start GitLab Runner
       command: "{{ gitlab_runner_executable }} start"
-  when: gitlab_runner_exists
+  when:
+    - gitlab_runner_exists
+    - gitlab_runner_existing_version != gitlab_runner_wanted_version or gitlab_runner_wanted_version == 'latest'

--- a/tasks/install-macos.yml
+++ b/tasks/install-macos.yml
@@ -1,0 +1,56 @@
+- name: (MacOS) PRE-CHECK GitLab Runner exists
+  block:
+  - name: (MacOS) Check gitlab-runner executable exists
+    stat:
+      path: "{{ gitlab_runner_executable }}"
+    register: gitlab_runner_exists
+
+  - name: (MacOS) Set fact -> gitlab_runner_exists
+    set_fact:
+      gitlab_runner_exists: "{{ gitlab_runner_exists.stat.exists }}"
+
+- name: (MacOS) INSTALL GitLab Runner for macOS
+  block:
+    - name: (MacOS) Download GitLab Runner
+      get_url:
+        url: https://gitlab-runner-downloads.s3.amazonaws.com/latest/binaries/gitlab-runner-darwin-amd64
+        dest: "{{ gitlab_runner_executable }}"
+        validate_certs: no
+
+    - name: (MacOS) Setting Permissions for gitlab-runner executable
+      file:
+        path: "{{ gitlab_runner_executable }}"
+        owner: "{{ ansible_user_id | string }}"
+        group: "{{ ansible_user_gid | string }}"
+        mode: '+x'
+
+    - name: (MacOS) Install GitLab Runner
+      command: "{{ gitlab_runner_executable }} install"
+
+    - name: (MacOS) Start GitLab Runner
+      command: "{{ gitlab_runner_executable }} start"
+
+  when: (not gitlab_runner_exists)
+
+- name: (MacOS) UPGRADE GitLab Runner for macOS
+  block:
+    - name: (MacOS) Stop GitLab Runner
+      command: "{{ gitlab_runner_executable }} stop"
+
+    - name: (MacOS) Download GitLab Runner
+      get_url:
+        url: https://gitlab-runner-downloads.s3.amazonaws.com/latest/binaries/gitlab-runner-darwin-amd64
+        dest: "{{ gitlab_runner_executable }}"
+        validate_certs: no
+
+    - name: (MacOS) Setting Permissions for gitlab-runner executable
+      file:
+        path: "{{ gitlab_runner_executable }}"
+        owner: "{{ ansible_user_id | string }}"
+        group: "{{ ansible_user_gid | string }}"
+        mode: '+x'
+      become: yes
+
+    - name: (MacOS) Start GitLab Runner
+      command: "{{ gitlab_runner_executable }} start"
+  when: gitlab_runner_exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Load platform-specific variables
+  include_vars: "{{ lookup('first_found', possible_files) }}"
+  vars:
+    possible_files:
+      files:
+        - '{{ ansible_distribution }}.yml'
+        - '{{ ansible_os_family }}.yml'
+        - default.yml
+      paths:
+        - 'vars'
+
 - name: Install GitLab Runner (Debian)
   import_tasks: install-debian.yml
   when: ansible_os_family == 'Debian'
@@ -7,12 +18,23 @@
   import_tasks: install-redhat.yml
   when: ansible_os_family == 'RedHat'
 
+- name: Install GitLab Runner (macOS)
+  import_tasks: install-macos.yml
+  when: ansible_os_family == 'Darwin'
+
 - name: Set global options
   import_tasks: global-setup.yml
 
 - name: List configured runners
-  command: gitlab-runner list
+  command: "{{ gitlab_runner_executable }} list"
   register: configured_runners
+  changed_when: False
+  check_mode: no
+
+- name: Check runner is registered
+  command: "{{ gitlab_runner_executable }} verify"
+  register: verified_runners
+  ignore_errors: True
   changed_when: False
   check_mode: no
 

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -1,4 +1,25 @@
 ---
+- name: Clear Config File
+  block:
+    - name: remove config.toml file
+      file:
+        path: "{{ gitlab_runner_config_file }}"
+        state: absent
+
+    - name: Create .gitlab-runner dir
+      file:
+        path: "{{ gitlab_runner_config_file_location }}"
+        state: directory
+        mode: '0755'
+
+    - name: Ensure config.toml exists
+      file:
+        path: "{{ gitlab_runner_config_file }}"
+        state: touch
+        modification_time: preserve
+        access_time: preserve
+  when: (verified_runners.stderr.find("Verifying runner... is removed") != -1)
+
 - name: Register runner to GitLab
   command: >
     gitlab-runner register
@@ -61,8 +82,8 @@
     {% if gitlab_runner.extra_registration_option is defined %}
     {{ gitlab_runner.extra_registration_option }}
     {% endif %}
-  when:
-    - configured_runners.stderr.find('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) == -1
-    - gitlab_runner.state|default('present') == 'present'
+  when: (verified_runners.stderr.find("Verifying runner... is removed") != -1) or
+        ((configured_runners.stderr.find('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) == -1) and
+        (gitlab_runner.state|default('present') == 'present'))
   no_log: true
   become: true

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,7 +1,5 @@
 ---
 - hosts: localhost
-  remote_user: root
-  become: true
   vars:
     gitlab_runner_runners:
       - name: 'vagrant-shell'

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,0 +1,6 @@
+---
+
+gitlab_runner_config_file: "{{ gitlab_runner_config_file_location }}/config.toml"  # on macOS
+
+gitlab_wrapper_script_name: gitlab-runner-wrapper-macos.sh
+gitlab_runner_executable: "/usr/local/bin/{{ gitlab_runner_package_name }}"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,3 @@
+---
+
+gitlab_wrapper_script_name: gitlab-runner-wrapper.sh


### PR DESCRIPTION
This PR adds support for installing the gitlab CI runner on Mac OS machines (either the latest version or a specific version) with Travis CI tests to verify them on Linux and Mac.

Worth noting that the automated tests running in Travis CI do not actually do the registration; there is room for improvement by mocking the registration command and making sure it's being called when appropriate.