### PR TITLE
Enable listen_address for Prometheus metrics & monitoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Defaults to `https://gitlab.com/ci`.
 `gitlab_runner_sentry_dsn`
 Enable tracking of all system level errors to Sentry
 
+`gitlab_runner_listen_address`
+Enable `/metrics` endpoint for Prometheus scraping.
+
 `gitlab_runner_runners`
 A list of gitlab runners to register & configure. Defaults to a single shell executor. See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file listing all possible options which you can be passed to a runner registration command.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ gitlab_runner_registration_token: ''
 
 gitlab_runner_sentry_dsn: ''
 
+# Prometheus Metrics & Monitoring
+gitlab_runner_listen_address: ''
+
 # A list of runners to register and configure
 gitlab_runner_runners:
     # The identifier of the runner.

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -17,6 +17,17 @@
   notify: restart_gitlab_runner
   become: true
 
+- name: Add listen_address to config
+  lineinfile:
+    dest: /etc/gitlab-runner/config.toml
+    regexp: '^listen_address ='
+    line: 'listen_address = "{{ gitlab_runner_listen_address }}"'
+    insertafter: '\s*concurrent.*'
+    state: present
+  when: gitlab_runner_listen_address | length > 0  # Ensure value is set
+  notify: restart_gitlab_runner
+  become: true
+
 - name: Add sentry dsn to config
   lineinfile:
     dest: /etc/gitlab-runner/config.toml


### PR DESCRIPTION
This PR enables `listen_address` feature in `gitlab-runner`. It results in opening port for Prometheus scraping the `/metrics` endpoint. Examples:

```
gitlab_runner_listen_address: ":9252"
gitlab_runner_listen_address: "localhost:9252"
```

Here's `gitlab-runner` documentation for the reference: [GitLab Runner monitoring](https://docs.gitlab.com/runner/monitoring/README.html).

Closes #75 