### PR TITLE
Add cache settings to correct sections

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -87,13 +87,37 @@
   check_mode: no
   notify: restart_gitlab_runner
 
+
+#### [runners.cache] section ####
+- name: Set cache section
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*\[runners.cache\]\*$'
+    line: '  [runners.cache]'
+    state: present
+    insertafter: EOF
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
+- name: Set cache s3 section
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*\[runners.cache.s3\]'
+    line: '    [runners.cache.s3]'
+    state: "{{ 'present' if gitlab_runner.cache_s3_server_address is defined else 'absent' }}"
+    insertafter: '^\s*\[runners.cache\]'
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
 - name: Set cache type option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Type ='
-    line: '  Type = {{ gitlab_runner.cache_type|default("") | to_json }}'
+    line: '    Type = {{ gitlab_runner.cache_type|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_type is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.cache\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -102,20 +126,33 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Path ='
-    line: '  Path = {{ gitlab_runner.cache_path|default("") | to_json }}'
+    line: '    Path = {{ gitlab_runner.cache_path|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_path is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.cache\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
 
+- name: Set cache shared option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*Shared ='
+    line: '    Shared = {{ gitlab_runner.cache_shared|default("") | lower }}'
+    state: "{{ 'present' if gitlab_runner.cache_shared is defined else 'absent' }}"
+    insertafter: '^\s*\[runners.cache\]'
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
+
+#### [runners.cache.s3] section ####
 - name: Set cache s3 server addresss
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*ServerAddress ='
-    line: '  ServerAddress = {{ gitlab_runner.cache_s3_server_address|default("") | to_json }}'
+    line: '      ServerAddress = {{ gitlab_runner.cache_s3_server_address|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_server_address is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.cache.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -124,9 +161,9 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*AccessKey ='
-    line: '  AccessKey = {{ gitlab_runner.cache_s3_access_key|default("") | to_json }}'
+    line: '      AccessKey = {{ gitlab_runner.cache_s3_access_key|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_access_key is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.cache.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -135,21 +172,9 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*SecretKey ='
-    line: '  SecretKey = {{ gitlab_runner.cache_s3_secret_key|default("") | to_json }}'
+    line: '      SecretKey = {{ gitlab_runner.cache_s3_secret_key|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_secret_key is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
-    backrefs: no
-  check_mode: no
-  notify: restart_gitlab_runner
-
-
-- name: Set cache shared option
-  lineinfile:
-    dest: "{{ temp_runner_config.path }}"
-    regexp: '^\s*Shared ='
-    line: '  Shared = {{ gitlab_runner.cache_shared|default("") | lower }}'
-    state: "{{ 'present' if gitlab_runner.cache_shared is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.cache.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -158,9 +183,9 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*BucketName ='
-    line: '  BucketName = {{ gitlab_runner.cache_s3_bucket_name|default("")  | to_json }}'
+    line: '      BucketName = {{ gitlab_runner.cache_s3_bucket_name|default("")  | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_bucket_name is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.cache.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -169,9 +194,9 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*BucketLocation ='
-    line: '  BucketLocation = {{ gitlab_runner.cache_s3_bucket_location|default("") | to_json }}'
+    line: '      BucketLocation = {{ gitlab_runner.cache_s3_bucket_location|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_bucket_location is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.cache.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -180,9 +205,9 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Insecure ='
-    line: '  Insecure = {{ gitlab_runner.cache_s3_insecure|default("") | lower }}'
+    line: '      Insecure = {{ gitlab_runner.cache_s3_insecure|default("") | lower }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_insecure is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.cache.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -43,6 +43,17 @@
   check_mode: no
   notify: restart_gitlab_runner
 
+- name: Set runner executor section
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*[runners.{{ gitlab_runner.executor|default("shell") }}]'
+    line: '  [runners.{{ gitlab_runner.executor|default("shell") }}]'
+    state: present
+    insertafter: '^\s*executor ='
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
 - name: Set output_limit option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
@@ -54,13 +65,15 @@
   check_mode: no
   notify: restart_gitlab_runner
 
+
+#### [runners.docker] section ####
 - name: Set runner docker image option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*image ='
-    line: '  image = {{ gitlab_runner.docker_image|default("") | to_json }}'
+    line: '    image = {{ gitlab_runner.docker_image|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.docker_image is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.docker\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -69,9 +82,9 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*privileged ='
-    line: '  privileged = {{ gitlab_runner.docker_privileged|default(false) | lower }}'
+    line: '    privileged = {{ gitlab_runner.docker_privileged|default(false) | lower }}'
     state: "{{ 'present' if gitlab_runner.docker_privileged is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.docker\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -80,7 +93,7 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*volumes ='
-    line: '  volumes = {{ gitlab_runner.docker_volumes|default([])|to_json }}'
+    line: '    volumes = {{ gitlab_runner.docker_volumes|default([])|to_json }}'
     state: "{{ 'present' if gitlab_runner.docker_volumes is defined else 'absent' }}"
     insertafter: '^\s*executor ='
     backrefs: no
@@ -212,13 +225,15 @@
   check_mode: no
   notify: restart_gitlab_runner
 
+
+#### [runners.ssh] section #####
 - name: Set ssh user option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*user ='
     line: '  user = {{ gitlab_runner.ssh_user|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.ssh_user is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.ssh\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -229,7 +244,7 @@
     regexp: '^\s*host ='
     line: '  host = {{ gitlab_runner.ssh_host|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.ssh_host is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.ssh\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -240,7 +255,7 @@
     regexp: '^\s*port ='
     line: '  port = {{ gitlab_runner.ssh_port|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.ssh_port is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.ssh\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -251,7 +266,7 @@
     regexp: '^\s*password ='
     line: '  password = {{ gitlab_runner.ssh_password|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.ssh_password is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.ssh\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
@@ -262,10 +277,11 @@
     regexp: '^\s*identity_file ='
     line: '  identity_file = {{ gitlab_runner.ssh_identity_file|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.ssh_identity_file is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners.ssh\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
+
 
 - name: Set builds dir file option
   lineinfile:

--- a/tests/vars/default.yml
+++ b/tests/vars/default.yml
@@ -1,3 +1,4 @@
+---
 gitlab_runner_runners:
   - name: 'vagrant-shell'
     executor: shell
@@ -12,3 +13,19 @@ gitlab_runner_runners:
       - node
       - ruby
       - mysql
+  - name: 'vagrant-docker-cache'
+    executor: docker
+    docker_image: 'docker:stable'
+    tags:
+      - node
+      - ruby
+      - mysql
+      - cache
+    cache_type: s3
+    cache_shared: true
+    cache_s3_server_address: mycache.example.com
+    cache_s3_access_key: myaccess-key
+    cache_s3_secret_key: mysecret-key
+    cache_s3_bucket_name: build-cache-bucket
+    cache_s3_insecure: false
+...


### PR DESCRIPTION
The config-parameters of the cache section were put into the `[runners]`-section, when using the `gitlab_runner.cache_*`-variables.

I had to use them because ansible complained that `.` was not allowed in Hash-Keys and therefore I could not use the `extra_configs`-key in `gitlab_runner_runners`-variable.

Fixes #72 