### PR TITLE
Make executor section conditional

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -48,7 +48,7 @@
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.{{ gitlab_runner.executor|default("shell") }}\]'
     line: '  [runners.{{ gitlab_runner.executor|default("shell") }}]'
-    state: present
+    state: "{{ 'absent' if (gitlab_runner.executor|default('shell')) == 'shell' else 'present' }}"
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no


### PR DESCRIPTION
When setting up a shell runner, I ran into a verification error:

```
FATAL: toml: cannot load TOML value of type map[string]interface {} into a Go string
```

Tracing it back, it appears that the [gitlab-runner is expecting a string](https://gitlab.com/gitlab-org/gitlab-runner/blob/c6bd01357946bc57cfcc490549d93fc26332dbc1/common/config.go#L304) for the `shell` attribute, but choking on `runners.shell` being a map. Since there
is no additional shell configuration, this patch makes the executor section conditional on the
executor type being something other than `shell`.