### PR TITLE
Run list and verify methods as privileged user

### DIFF
--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -19,6 +19,7 @@
   register: configured_runners
   changed_when: False
   check_mode: no
+  become: yes
 
 - name: (Unix) Check runner is registered
   command: "{{ gitlab_runner_executable }} verify"
@@ -26,6 +27,7 @@
   ignore_errors: True
   changed_when: False
   check_mode: no
+  become: yes
 
 - name: (Unix) Register GitLab Runner
   include_tasks: register-runner.yml


### PR DESCRIPTION
Need to run the `List configured runners` and `Check runner is registered` as the privileged user so that it picks up the global config.toml and not the non-existent one in the user's home directory.
This addresses issue #89