### PR TITLE
Fix runner config path on Windows listen_address

### DIFF
--- a/tasks/global-setup-windows.yml
+++ b/tasks/global-setup-windows.yml
@@ -25,7 +25,7 @@
 
 - name: (Windows) Add listen_address to config
   win_lineinfile:
-    dest: /etc/gitlab-runner/config.toml
+    dest: "{{ gitlab_runner_config_file }}"
     regexp: '^listen_address =.*'
     line: 'listen_address = "{{ gitlab_runner_listen_address }}"'
     insertafter: '\s*concurrent.*'

--- a/tests/vars/Windows.yml
+++ b/tests/vars/Windows.yml
@@ -11,3 +11,5 @@ gitlab_runner_runners:
       - docker
     executor: docker-windows
     state: present
+
+gitlab_runner_listen_address: '0.0.0.0:9001'


### PR DESCRIPTION
Task "(Windows) Add listen_address to config" was using a fixed path for the runner config file