### PR TITLE
Making s3 access key and secret key as optional

### DIFF
--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -70,7 +70,11 @@
     {% endif %}
     {% if gitlab_runner.cache_s3_server_address is defined %}
     --cache-s3-server-address '{{ gitlab_runner.cache_s3_server_address }}'
+    {% endif %}
+    {% if gitlab_runner.cache_s3_access_key is defined %}
     --cache-s3-access-key '{{ gitlab_runner.cache_s3_access_key }}'
+    {% endif %}
+    {% if gitlab_runner.cache_s3_secret_key is defined %}
     --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
     {% endif %}
     {% if gitlab_runner.cache_s3_bucket_name is defined %}


### PR DESCRIPTION
In order to make s3 cache authentication through IAM instance profile,
s3 access key and secret key were converted to optional parameters