### PR TITLE
Fix windows cache s3 config order

### DIFF
--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -127,7 +127,7 @@
     regexp: '^\s*ServerAddress =.*'
     line: '  ServerAddress = {{ gitlab_runner.cache_s3_server_address|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_server_address is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner_windows
@@ -138,7 +138,7 @@
     regexp: '^\s*AccessKey =.*'
     line: '  AccessKey = {{ gitlab_runner.cache_s3_access_key|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_access_key is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner_windows
@@ -149,7 +149,7 @@
     regexp: '^\s*SecretKey =.*'
     line: '  SecretKey = {{ gitlab_runner.cache_s3_secret_key|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_secret_key is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner_windows
@@ -172,7 +172,7 @@
     regexp: '^\s*BucketName =.*'
     line: '  BucketName = {{ gitlab_runner.cache_s3_bucket_name|default("")  | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_bucket_name is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner_windows
@@ -183,7 +183,7 @@
     regexp: '^\s*BucketLocation =.*'
     line: '  BucketLocation = {{ gitlab_runner.cache_s3_bucket_location|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_bucket_location is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner_windows
@@ -194,7 +194,7 @@
     regexp: '^\s*Insecure =.*'
     line: '  Insecure = {{ gitlab_runner.cache_s3_insecure|default("") | lower }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_insecure is defined else 'absent' }}"
-    insertafter: '^\s*executor ='
+    insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner_windows

--- a/tests/vars/Windows.yml
+++ b/tests/vars/Windows.yml
@@ -5,6 +5,19 @@ gitlab_runner_runners:
       - shell
     executor: shell
     state: present
+  - name: "Shell Runner S3 Cache"
+    tags:
+      - windows
+      - shell
+    executor: shell
+    cache_type: s3
+    cache_shared: true
+    cache_s3_server_address: mycache.example.com
+    cache_s3_access_key: myaccess-key
+    cache_s3_secret_key: mysecret-key
+    cache_s3_bucket_name: build-cache-bucket
+    cache_s3_insecure: false
+    state: present
   - name: "Docker Runner"
     tags:
       - windows


### PR DESCRIPTION
S3 cache directives were out of order on the runner `config.toml`, now we are applying the same regex to configure s3 cache on Windows and Linux.