### PR TITLE
Allow GCS cache configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -98,6 +98,18 @@ gitlab_runner_runners:
     # Cache S3 insecure
     # cache_s3_insecure: false
     #
+    # Cache GCS Bucket name
+    # cache_gcs_bucket_name: "my-bucket"
+    #
+    # Cache GCS CredentialsFile
+    # cache_gcs_credentials_file: "/path/to/key_file.json"
+    #
+    # Cache GCS Access ID
+    # cache_gcs_access_id: "cache-access-account@project.iam.gserviceaccount.com"
+    #
+    # Cache GCS Private Key
+    # cache_gcs_private_key: "-----BEGIN PRIVATE KEY-----\nXXXXXX\n-----END PRIVATE KEY-----\n"
+    #
     # Builds directory
     # builds_dir: '/builds_dir'
     #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,7 +72,7 @@ gitlab_runner_runners:
     # ssh_identity_file: ''
     #
     # Cache type
-    # cache_type: 's3'
+    # cache_type: 's3|gcs'
     #
     # Cache path
     # cache_path: prefix/key

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -136,6 +136,17 @@
   check_mode: no
   notify: restart_gitlab_runner
 
+- name: Set cache gcs section
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*\[runners\.cache\.gcs\]'
+    line: '    [runners.cache.gcs]'
+    state: "{{ 'present' if gitlab_runner.cache_gcs_bucket_name is defined else 'absent' }}"
+    insertafter: '^\s*\[runners\.cache\]'
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
 - name: Set cache type option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
@@ -233,6 +244,52 @@
     line: '      Insecure = {{ gitlab_runner.cache_s3_insecure|default("") | lower }}'
     state: "{{ 'present' if gitlab_runner.cache_s3_insecure is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.cache\.s3\]'
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
+
+#### [runners.cache.gcs] section ####
+- name: Set cache gcs bucket name
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*BucketName ='
+    line: '      BucketName = {{ gitlab_runner.cache_gcs_bucket_name|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.cache_gcs_bucket_name is defined else 'absent' }}"
+    insertafter: '^\s*\[runners\.cache\.gcs\]'
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
+- name: Set cache gcs credentials file
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*CredentialsFile ='
+    line: '      CredentialsFile = {{ gitlab_runner.cache_gcs_credentials_file|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.cache_gcs_credentials_file is defined else 'absent' }}"
+    insertafter: '^\s*\[runners\.cache\.gcs\]'
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
+- name: Set cache gcs access id
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*AccessID ='
+    line: '      AccessID = {{ gitlab_runner.cache_gcs_access_id|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.cache_gcs_access_id is defined else 'absent' }}"
+    insertafter: '^\s*\[runners\.cache\.gcs\]'
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+
+- name: Set cache gcs private key
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*PrivateKey ='
+    line: '      PrivateKey = {{ gitlab_runner.cache_gcs_private_key|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.cache_gcs_private_key is defined else 'absent' }}"
+    insertafter: '^\s*\[runners\.cache\.gcs\]'
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner

--- a/tests/vars/default.yml
+++ b/tests/vars/default.yml
@@ -28,4 +28,19 @@ gitlab_runner_runners:
     cache_s3_secret_key: mysecret-key
     cache_s3_bucket_name: build-cache-bucket
     cache_s3_insecure: false
+
+  - name: 'vagrant-docker-cache-gcs'
+    executor: docker
+    docker_image: 'docker:stable'
+    tags:
+      - node
+      - ruby
+      - mysql
+      - cache
+    cache_type: gcs
+    cache_shared: true
+    cache_gcs_bucket_name: gcs-cache-bucket
+    cache_gcs_credentials_file: '/etc/gitlab-runner/credentials.json'
+    cache_gcs_access_id: 'cache-access-account@project.iam.gserviceaccount.com'
+    cache_gcs_private_key: "-----BEGIN PRIVATE KEY-----\nXXXXXX\n-----END PRIVATE KEY-----\n"
 ...


### PR DESCRIPTION
It seems that now the default gitlab-runner configuration comes with GCS cache enabled. I haven't ben able to really test this, as I don't use GCS, and I just wanted to get rid of the configurations.

I have only been able to do some smoke tests (setting vars and confirm that the confgs appear in config.toml), other than that, this could be considered as untested.

Thanks!