### PR TITLE
Fix s3 cache section

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -225,6 +225,7 @@
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
+  when: gitlab_runner.cache_type == 's3'
 
 - name: Set cache s3 bucket location option
   lineinfile:
@@ -260,6 +261,7 @@
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
+  when: gitlab_runner.cache_type == 'gcs'
 
 - name: Set cache gcs credentials file
   lineinfile:
@@ -350,7 +352,6 @@
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
-
 
 - name: Set builds dir file option
   lineinfile:

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -130,7 +130,7 @@
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.cache\.s3\]'
     line: '    [runners.cache.s3]'
-    state: "{{ 'present' if gitlab_runner.cache_s3_server_address is defined else 'absent' }}"
+    state: "{{ 'present' if gitlab_runner.cache_type == 's3' else 'absent' }}"
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no


### PR DESCRIPTION
This PR fixes s3 section in config.toml

- set cache_s3_server_address as optional and generate runners.cache.s3 when cache is *s3*. The default server is AWS s3.
- mutex the "BucketName" tasks as both gcs and s3 use "^\s*BucketName" regexp

