### PR TITLE
Allow registration token per runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Inside `vars/main.yml`
 gitlab_runner_registration_token: 'HUzTMgnxk17YV8Rj8ucQ'
 gitlab_runner_runners:
   - name: 'Example Docker GitLab Runner'
+    # token is an optional override to the global gitlab_runner_registration_token
+    token: 'HUzTMgnxk17YV8Rj8ucQ' 
     executor: docker
     docker_image: 'alpine'
     tags:

--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -31,7 +31,7 @@
 
 - name: (Unix) Register GitLab Runner
   include_tasks: register-runner.yml
-  when: gitlab_runner_registration_token | string | length > 0  # Ensure value is set
+  when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0  # Ensure value is set
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     index_var: gitlab_runner_index

--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -19,6 +19,7 @@
   register: configured_runners
   changed_when: False
   check_mode: no
+  become: yes
 
 - name: (Unix) Check runner is registered
   command: "{{ gitlab_runner_executable }} verify"
@@ -26,6 +27,7 @@
   ignore_errors: True
   changed_when: False
   check_mode: no
+  become: yes
 
 - name: (Unix) Register GitLab Runner
   include_tasks: register-runner.yml

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -20,7 +20,7 @@
 
 - name: (Windows) Register GitLab Runner
   include_tasks: register-runner-windows.yml
-  when: gitlab_runner_registration_token | string | length > 0  # Ensure value is set
+  when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0  # Ensure value is set
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     index_var: gitlab_runner_index


### PR DESCRIPTION
Turns out you already accounted for a token per runner with this line:

`--registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'`

in both Unix and Windows.  This PR updates the conditional register-runner.yml to look at the specific or the global token.  It also updates the README to indicate that this is an option.

Closes #99 