### PR TITLE
Support system-mode and user-mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
             - python-pip
       install:
         # Install ansible
-        - pip install ansible
+        - pip install ansible flask
         # Check ansible version
         - ansible --version
         # Create ansible.cfg with correct roles_path
@@ -21,6 +21,9 @@ jobs:
         - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
         # Running tests
         - ansible-playbook tests/test.yml -i tests/inventory
+      after_failure:
+        - touch ~/mock_ci.pid && cat ~/mock_ci.pid
+        - touch ~/mock_ci.log && cat ~/mock_ci.log
     - os: osx
       osx_image: xcode10.3
       # See https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-422830059
@@ -28,7 +31,7 @@ jobs:
       language: generic
       install:
         # Install ansible
-        - pip install ansible
+        - pip install ansible flask
         # Check ansible version
         - ansible --version
         # Create ansible.cfg with correct roles_path
@@ -38,6 +41,9 @@ jobs:
         - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
         # Running tests
         - ansible-playbook tests/test.yml -i tests/inventory
+      after_failure:
+        - touch ~/mock_ci.pid && cat ~/mock_ci.pid
+        - touch ~/mock_ci.log && cat ~/mock_ci.log
     - os: windows
       language: shell
       install:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,17 +2,18 @@
 # for versions >= 10.x
 gitlab_runner_package_name: 'gitlab-runner'
 
-gitlab_runner_config_file_location: "{{ ansible_env.HOME }}/.gitlab-runner"
+gitlab_runner_system_mode: yes
 
 # gitlab_runner_package_version for version pinning on debian/redhat
 # The following are for version pinning on MacOSX
 gitlab_runner_wanted_version: latest
 
-# These two variable should not be modified usually as they depend on the gitlab_runner_wanted_version variable
+# This variable should not be modified usually as it depends on the gitlab_runner_wanted_version variable
 gitlab_runner_wanted_tag: "{{ 'latest' if gitlab_runner_wanted_version == 'latest' else ('v' + gitlab_runner_wanted_version) }}"
 
 # Overridden based on platform
-gitlab_runner_config_file: "/etc/gitlab-runner/config.toml"
+gitlab_runner_config_file: "{{ __gitlab_runner_config_file_system_mode if gitlab_runner_system_mode else __gitlab_runner_config_file_user_mode }}"
+gitlab_runner_config_file_location: "{{ gitlab_runner_config_file | dirname }}"
 gitlab_runner_executable: "{{ gitlab_runner_package_name }}"
 
 # Maximum number of global jobs to run concurrently
@@ -130,5 +131,3 @@ gitlab_runner_runners:
     #     allowed_images: ["ruby:*", "python:*", "php:*"]
     #   runners.docker.sysctls:
     #     net.ipv4.ip_forward: "1"
-
-gitlab_runner_temp_dir: /tmp

--- a/files/gitlab-runner-wrapper-macos.sh
+++ b/files/gitlab-runner-wrapper-macos.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-CONFIG_FILE=${1} /usr/local/bin/gitlab-runner verify

--- a/files/gitlab-runner-wrapper.sh
+++ b/files/gitlab-runner-wrapper.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-CONFIG_FILE=${1} /usr/bin/gitlab-runner verify

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,7 @@
 # macOS
 - name: restart_gitlab_runner_macos
   command: "{{ gitlab_runner_executable }} restart"
-  become: yes
+  become: gitlab_runner_system_mode
   when: ansible_os_family == 'Darwin'
 
 - name: restart_gitlab_runner_windows

--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -3,7 +3,7 @@
   slurp:
     src: "{{ gitlab_runner_config_file }}"
   register: runner_config_file
-  become: true
+  become: gitlab_runner_system_mode
 
 - name: Get pre-existing runner configs
   set_fact:
@@ -24,19 +24,12 @@
     index_var: runner_config_index
     loop_var: runner_config
 
-- name: Copy gitlab-runner-wrapper.sh
-  copy:
-    src: "{{ gitlab_wrapper_script_name }}"
-    dest: "{{ gitlab_runner_temp_dir|default('/tmp', true) }}/gitlab-runner-wrapper.sh"
-    mode: 0700
-  become: true
-
 - name: Assemble new config.toml
   assemble:
     src: "{{ temp_runner_config_dir.path }}"
     dest: "{{ gitlab_runner_config_file }}"
     delimiter: '[[runners]]\n'
     backup: yes
-    validate: "{{ gitlab_runner_temp_dir|default('/tmp', true) }}/gitlab-runner-wrapper.sh %s"
+    validate: "{{ gitlab_runner_executable }} verify -c %s"
     mode: 0600
-  become: true
+  become: gitlab_runner_system_mode

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -4,6 +4,7 @@
     path: "{{ gitlab_runner_config_file_location }}"
     state: directory
     mode: '0755'
+  become: gitlab_runner_system_mode
 
 - name: Ensure config.toml exists
   file:
@@ -11,7 +12,7 @@
     state: touch
     modification_time: preserve
     access_time: preserve
-  become: true
+  become: gitlab_runner_system_mode
 
 - name: Set concurrent option
   lineinfile:
@@ -20,21 +21,23 @@
     line: '\1concurrent = {{ gitlab_runner_concurrent }}'
     state: present
     backrefs: yes
-  become: true
+  become: gitlab_runner_system_mode
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
 - name: Add listen_address to config
   lineinfile:
-    dest: /etc/gitlab-runner/config.toml
+    dest: "{{ gitlab_runner_config_file }}"
     regexp: '^listen_address ='
     line: 'listen_address = "{{ gitlab_runner_listen_address }}"'
     insertafter: '\s*concurrent.*'
     state: present
   when: gitlab_runner_listen_address | length > 0  # Ensure value is set
-  notify: restart_gitlab_runner
-  become: true
+  become: gitlab_runner_system_mode
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
 
 - name: Add sentry dsn to config
   lineinfile:
@@ -44,7 +47,7 @@
     insertafter: '\s*concurrent.*'
     state: present
   when: gitlab_runner_sentry_dsn | length > 0  # Ensure value is set
-  become: true
+  become: gitlab_runner_system_mode
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -5,12 +5,14 @@
       file:
         path: "{{ gitlab_runner_config_file }}"
         state: absent
+      become: gitlab_runner_system_mode
 
     - name: Create .gitlab-runner dir
       file:
         path: "{{ gitlab_runner_config_file_location }}"
         state: directory
         mode: '0755'
+      become: gitlab_runner_system_mode
 
     - name: Ensure config.toml exists
       file:
@@ -18,6 +20,7 @@
         state: touch
         modification_time: preserve
         access_time: preserve
+      become: gitlab_runner_system_mode
   when: (verified_runners.stderr.find("Verifying runner... is removed") != -1)
 
 - name: Register runner to GitLab
@@ -95,4 +98,4 @@
         ((configured_runners.stderr.find('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) == -1) and
         (gitlab_runner.state|default('present') == 'present'))
   no_log: true
-  become: true
+  become: gitlab_runner_system_mode

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -8,7 +8,9 @@
     insertafter: '^\s*name ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set coordinator URL
   lineinfile:
@@ -19,7 +21,9 @@
     insertafter: '^\s*limit ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set environment option
   lineinfile:
@@ -30,7 +34,9 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set pre_clone_script
   lineinfile:
@@ -41,7 +47,9 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
   when: gitlab_runner.pre_clone_script is defined
 
 - name: Set runner executor option
@@ -53,7 +61,9 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set runner executor section
   lineinfile:
@@ -64,7 +74,9 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set output_limit option
   lineinfile:
@@ -75,7 +87,9 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 
 #### [runners.docker] section ####
@@ -88,7 +102,9 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set docker privileged option
   lineinfile:
@@ -99,7 +115,9 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set docker tlsverify option
   lineinfile:
@@ -110,7 +128,9 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set docker DNS option
   lineinfile:
@@ -121,7 +141,9 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set docker volumes option
   lineinfile:
@@ -132,7 +154,9 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 
 #### [runners.cache] section ####
@@ -145,7 +169,9 @@
     insertafter: EOF
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache s3 section
   lineinfile:
@@ -156,7 +182,9 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache gcs section
   lineinfile:
@@ -167,7 +195,9 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache type option
   lineinfile:
@@ -178,7 +208,9 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache path option
   lineinfile:
@@ -189,7 +221,9 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache shared option
   lineinfile:
@@ -200,7 +234,9 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 
 #### [runners.cache.s3] section ####
@@ -213,7 +249,9 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache s3 access key
   lineinfile:
@@ -224,7 +262,9 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache s3 secret key
   lineinfile:
@@ -235,7 +275,9 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache s3 bucket name option
   lineinfile:
@@ -246,7 +288,9 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
   when: gitlab_runner.cache_type is defined and gitlab_runner.cache_type == 's3'
 
 - name: Set cache s3 bucket location option
@@ -258,7 +302,9 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache s3 insecure option
   lineinfile:
@@ -269,7 +315,9 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 
 #### [runners.cache.gcs] section ####
@@ -282,7 +330,9 @@
     insertafter: '^\s*\[runners\.cache\.gcs\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
   when: gitlab_runner.cache_type is defined and gitlab_runner.cache_type == 'gcs'
 
 - name: Set cache gcs credentials file
@@ -294,7 +344,9 @@
     insertafter: '^\s*\[runners\.cache\.gcs\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache gcs access id
   lineinfile:
@@ -305,7 +357,9 @@
     insertafter: '^\s*\[runners\.cache\.gcs\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache gcs private key
   lineinfile:
@@ -316,7 +370,9 @@
     insertafter: '^\s*\[runners\.cache\.gcs\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 
 #### [runners.ssh] section #####
@@ -329,7 +385,9 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set ssh host option
   lineinfile:
@@ -340,7 +398,9 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set ssh port option
   lineinfile:
@@ -351,7 +411,9 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set ssh password option
   lineinfile:
@@ -362,7 +424,9 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set ssh identity file option
   lineinfile:
@@ -373,7 +437,9 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set builds dir file option
   lineinfile:
@@ -384,7 +450,9 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Set cache dir file option
   lineinfile:
@@ -395,14 +463,16 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
-  notify: restart_gitlab_runner
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
 
 - name: Ensure directory permissions
   file:
     dest: "{{ item }}"
     state: directory
-    owner: gitlab-runner
-    group: gitlab-runner
+    owner: "{{ gitlab_runner_runtime_owner|default(omit) }}"
+    group: "{{ gitlab_runner_runtime_group|default(omit) }}"
     mode: 0770
     modification_time: preserve
     access_time: preserve
@@ -420,7 +490,7 @@
   when: item|length
   changed_when: False
   become: yes
-  become_user: gitlab-runner
+  become_user: gitlab_runner_runtime_owner|default(omit)
   register: ensure_directory_access
   ignore_errors: true
 

--- a/tests/files/mock_gitlab_runner_ci.py
+++ b/tests/files/mock_gitlab_runner_ci.py
@@ -1,0 +1,69 @@
+from __future__ import print_function
+import os
+import sys
+import logging
+import random
+
+from flask import Flask, Blueprint, request, jsonify
+
+app = Flask(__name__)
+bp = Blueprint(__name__, 'api', url_prefix='/api/v4')
+
+
+@bp.route('/runners', methods=['POST'])
+def register_runner():
+    logging.info("Got register_runner request: {!r}".format(request.data))
+    req = request.json
+    res = {}
+
+    token = req['token']
+    if token.isalnum() and token.islower():
+        res['token'] = "{}{}".format(token.upper(), random.randint(100, 999))
+        status = 201
+    elif token.isalnum() and token.isupper():
+        status = 403
+    else:
+        status = 400
+
+    return jsonify(res), status
+
+
+@bp.route('/runners/verify', methods=['POST'])
+def verify_runner():
+    logging.info("Got verify_runner request: {!r}".format(request.data))
+    req = request.json
+    res = {}
+
+    token = req['token']
+    if token.isalnum() and token.isupper():
+        status = 200
+    elif token.isalnum() and token.islower():
+        status = 403
+    else:
+        status = 400
+
+    return jsonify(res), status
+
+
+app.register_blueprint(bp)
+
+
+if __name__ == '__main__':
+    pid = str(os.getpid())
+    pidfile = os.path.expanduser(sys.argv[1])
+
+    if os.path.isfile(pidfile):
+        print("{} already exists, exiting".format(pidfile))
+        sys.exit(1)
+
+    port = int(sys.argv[2])
+
+    with open(pidfile, 'w') as f:
+        f.write(pid)
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    try:
+        app.run(port=port, debug=False)
+    finally:
+        os.unlink(pidfile)

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,12 +1,51 @@
 ---
 - hosts: localhost
-  vars:
-    possible_files:
-    files:
-      - '{{ ansible_distribution }}.yml'
-      - '{{ ansible_os_family }}.yml'
-      - default.yml
-    paths:
-      - 'vars'
+  tasks:
+    - name: Load platform-specific variables
+      include_vars: "{{ lookup('first_found', possible_files) }}"
+      vars:
+        possible_files:
+          files:
+            - '{{ ansible_distribution }}.yml'
+            - '{{ ansible_os_family }}.yml'
+            - default.yml
+          paths:
+            - 'vars'
+    - name: Copy the mock gitlab CI server
+      copy:
+        src: mock_gitlab_runner_ci.py
+        dest: "~/mock_gitlab_runner_ci.py"
+      when: run_mock_server
+    - name: Ensure mock CI pidfile is absent
+      file:
+        path: "~/mock_ci.pid"
+        state: absent
+      when: run_mock_server
+    - name: Run the mock CI
+      shell: "python ~/mock_gitlab_runner_ci.py ~/mock_ci.pid 6060  >~/mock_ci.log 2>&1"
+      async: 3600
+      poll: 0
+      register: mock_server
+      when: run_mock_server
+    - name: Wait for pidfile to be created
+      wait_for:
+        host: 127.0.0.1
+        port: 6060
+        delay: 1
+        timeout: 30
+      when: run_mock_server
+
+- hosts: localhost
   roles:
     - ansible-gitlab-runner
+
+- hosts: localhost
+  tasks:
+    - name: Get pid mock gitlab CI server
+      slurp:
+        src: "~/mock_ci.pid"
+      register: pidfile_b64
+      when: run_mock_server
+    - name: Run the mock CI
+      command: "kill {{ pidfile_b64.content | b64decode }}"
+      when: run_mock_server

--- a/tests/vars/Windows.yml
+++ b/tests/vars/Windows.yml
@@ -26,3 +26,7 @@ gitlab_runner_runners:
     state: present
 
 gitlab_runner_listen_address: '0.0.0.0:9001'
+
+run_mock_server: no
+gitlab_runner_coordinator_url: "http://localhost:7070/"
+gitlab_runner_registration_token: ''

--- a/tests/vars/default.yml
+++ b/tests/vars/default.yml
@@ -43,4 +43,10 @@ gitlab_runner_runners:
     cache_gcs_credentials_file: '/etc/gitlab-runner/credentials.json'
     cache_gcs_access_id: 'cache-access-account@project.iam.gserviceaccount.com'
     cache_gcs_private_key: "-----BEGIN PRIVATE KEY-----\nXXXXXX\n-----END PRIVATE KEY-----\n"
+
+run_mock_server: yes
+gitlab_runner_coordinator_url: "http://localhost:6060/"
+gitlab_runner_registration_token: 'notreal'
+
+gitlab_runner_system_mode: no
 ...

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,7 +1,5 @@
 ---
 
 gitlab_runner_download_url: 'https://gitlab-runner-downloads.s3.amazonaws.com/{{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-darwin-amd64'
-gitlab_runner_config_file: "{{ gitlab_runner_config_file_location }}/config.toml"  # on macOS
 
-gitlab_wrapper_script_name: gitlab-runner-wrapper-macos.sh
 gitlab_runner_executable: "/usr/local/bin/{{ gitlab_runner_package_name }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,6 @@
+---
+
+gitlab_runner_executable: "/usr/bin/{{ gitlab_runner_package_name }}"
+
+gitlab_runner_runtime_owner: gitlab-runner
+gitlab_runner_runtime_group: gitlab-runner

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,6 @@
+---
+
+gitlab_runner_executable: "/usr/bin/{{ gitlab_runner_package_name }}"
+
+gitlab_runner_runtime_owner: gitlab-runner
+gitlab_runner_runtime_group: gitlab-runner

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -6,6 +6,4 @@ gitlab_runner_install_directory: "c:/gitlab-runner/"
 gitlab_runner_config_file_location: "{{ gitlab_runner_install_directory }}"
 gitlab_runner_config_file: "{{ gitlab_runner_config_file_location }}/config.toml"  # on Windows
 
-gitlab_wrapper_script_name: gitlab-runner-wrapper-macos.ps1
-
 gitlab_runner_executable: "{{gitlab_runner_install_directory}}/{{ gitlab_runner_package_name }}.exe"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,3 +1,1 @@
 ---
-
-gitlab_wrapper_script_name: gitlab-runner-wrapper.sh

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,6 @@
 ---
 # vars file for gitlab-runner
+
+# Useful default paths for config files on Mac/Linux platforms
+__gitlab_runner_config_file_system_mode: "/etc/gitlab-runner/config.toml"
+__gitlab_runner_config_file_user_mode: "~/.gitlab-runner/config.toml"


### PR DESCRIPTION
There were some permission issues when setting up on mac because of the difference between user mode and system mode. This PR makes the distinction between the two clear, without changing the defaults for Linux.

Also improves tests by checking that the registration step actually executes successfully against a mock server.

(Those were some old changes that I rebased on the latest master, but it seems there should not be any major conflicts)