### PR TITLE
Fix become directives

### DIFF
--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -3,7 +3,7 @@
   slurp:
     src: "{{ gitlab_runner_config_file }}"
   register: runner_config_file
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"
 
 - name: Get pre-existing runner configs
   set_fact:
@@ -32,4 +32,4 @@
     backup: yes
     validate: "{{ gitlab_runner_executable }} verify -c %s"
     mode: 0600
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -4,7 +4,7 @@
     path: "{{ gitlab_runner_config_file_location }}"
     state: directory
     mode: '0755'
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"
 
 - name: Ensure config.toml exists
   file:
@@ -12,7 +12,7 @@
     state: touch
     modification_time: preserve
     access_time: preserve
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"
 
 - name: Set concurrent option
   lineinfile:
@@ -21,7 +21,7 @@
     line: '\1concurrent = {{ gitlab_runner_concurrent }}'
     state: present
     backrefs: yes
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -34,7 +34,7 @@
     insertafter: '\s*concurrent.*'
     state: present
   when: gitlab_runner_listen_address | length > 0  # Ensure value is set
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -47,7 +47,7 @@
     insertafter: '\s*concurrent.*'
     state: present
   when: gitlab_runner_sentry_dsn | length > 0  # Ensure value is set
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -5,14 +5,14 @@
       file:
         path: "{{ gitlab_runner_config_file }}"
         state: absent
-      become: gitlab_runner_system_mode
+      become: "{{ gitlab_runner_system_mode }}"
 
     - name: Create .gitlab-runner dir
       file:
         path: "{{ gitlab_runner_config_file_location }}"
         state: directory
         mode: '0755'
-      become: gitlab_runner_system_mode
+      become: "{{ gitlab_runner_system_mode }}"
 
     - name: Ensure config.toml exists
       file:
@@ -20,7 +20,7 @@
         state: touch
         modification_time: preserve
         access_time: preserve
-      become: gitlab_runner_system_mode
+      become: "{{ gitlab_runner_system_mode }}"
   when: (verified_runners.stderr.find("Verifying runner... is removed") != -1)
 
 - name: Register runner to GitLab
@@ -98,4 +98,4 @@
         ((configured_runners.stderr.find('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) == -1) and
         (gitlab_runner.state|default('present') == 'present'))
   no_log: true
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"


### PR DESCRIPTION
I'm using the default setting `gitlab_runner_system_mode: yes` and installing to Ubuntu and CentOS runner nodes with Ansible 2.8. Tasks that have `become: gitlab_runner_system_mode` directive fail with errors such as `Operation not permitted` or `file is not readable`, indicating that `become` is not working as intended.

The fix is to expand the `gitlab_runner_system_mode` variable in `become` directives.