### PR TITLE
Add clone_url option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,9 @@ gitlab_runner_runners:
     locked: 'false'
     # Custom environment variables injected to registration command
     env_vars: []
+    # Sets the clone_url. The default is not set.
+    # clone_url:
+    #
     # Sets the pre_clone_script. The default is not set.
     # pre_clone_script:
     #

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -27,6 +27,9 @@
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
     --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
     --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
+    {% if gitlab_runner.clone_url|default(false) %}
+    --clone-url "{{ gitlab_runner.clone_url }}"
+    {% endif %}
     {% if gitlab_runner.run_untagged|default(true) %}
     --run-untagged
     {% endif %}

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -31,6 +31,9 @@
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
     --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
     --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
+    {% if gitlab_runner.clone_url|default(false) %}
+    --clone-url "{{ gitlab_runner.clone_url }}"
+    {% endif %}
     {% if gitlab_runner.run_untagged|default(true) %}
     --run-untagged
     {% endif %}

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -21,6 +21,18 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
+- name: (Windows) Set clone URL
+  win_lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*clone_url ='
+    line: '  clone_url = {{ gitlab_runner.clone_url | to_json }}'
+    state: present
+    insertafter: '^\s*url ='
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+  when: gitlab_runner.clone_url is defined
+
 - name: (Windows) Set environment option
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -25,6 +25,20 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
+- name: Set clone URL
+  win_lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*clone_url ='
+    line: '  clone_url = {{ gitlab_runner.clone_url | to_json }}'
+    state: present
+    insertafter: '^\s*url ='
+    backrefs: no
+  check_mode: no
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
+  when: gitlab_runner.clone_url is defined
+
 - name: Set environment option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"


### PR DESCRIPTION
Maybe I miss something but there is an option clone_url for:


Overwrite the URL for the GitLab instance. Used if the Runner can’t connect to GitLab on the URL GitLab exposes itself.


from: https://docs.gitlab.com/runner/configuration/advanced-configuration.html