### PR TITLE
main.yml: Correct minor documentation error

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,7 @@ gitlab_runner_runners:
     docker_privileged: false
     # Runner Locked. When a runner is locked, it cannot be assigned to other projects
     locked: 'false'
-    # Custom environment variables injected to registration command
+    # Custom environment variables injected to build environment
     env_vars: []
     # Sets the clone_url. The default is not set.
     # clone_url:


### PR DESCRIPTION
env_vars correspond to the environment configuration that is used in the build environment not registration command.