### PR TITLE
Fix 'path does not exist' error when using Windows + --check.

### DIFF
--- a/tasks/config-runners-windows.yml
+++ b/tasks/config-runners-windows.yml
@@ -28,6 +28,7 @@
     loop_var: runner_config
 
 - name: (Windows) Assemble new config.toml
+  when: not ansible_check_mode
   block:
   - name: (Windows) Create temporary file config.toml
     win_tempfile:


### PR DESCRIPTION
Hi,

thank you for the great work!

We're running into a Windows-only issue when running `ansible-playbook --check` (the error does not happen without `--check`):

```
TASK [riemers.gitlab-runner : include] ****************************************************************************************************************************************************************************
skipping: [build-windows]

TASK [riemers.gitlab-runner : (Windows) Remove runner config] *****************************************************************************************************************************************************
skipping: [build-windows] => (item={'shell': 'powershell', 'cache_dir': 'C:\\gitlab-runner\\cache', 'tags': ['windows', 'powershell'], 'run_untagged': False, 'executor': 'shell', 'name': 'build-windows.aerys.in (PowerShell)', 'locked': False, 'builds_dir': 'C:\\gitlab-runner\\builds', 'concurrent_specific': 8}) 

TASK [riemers.gitlab-runner : (Windows) Create temporary file config.toml] ****************************************************************************************************************************************
changed: [build-windows]

TASK [riemers.gitlab-runner : (Windows) Write global config to file] **********************************************************************************************************************************************
fatal: [build-windows]: FAILED! => {"changed": false, "msg": "Path C:\\Users\\root\\AppData\\Local\\Temp\\ansible.zhtuq2sv.ox1temp does not exist !"}
```

The error message is `Path C:\\Users\\root\\AppData\\Local\\Temp\\ansible.zhtuq2sv.ox1temp does not exist !`.

My guess is the previous task does not actually create the temporary file when `--check` is used. I've verified this by adding `- pause: minutes=5` before the failing task and the temporary file is indeed nowhere to be found when `--check` is used.

I guess the only sensible thing is to disable the whole block when `--check` is used. Which is what this PR does.