### PR TITLE
Fix wrong include for section-config-runner on Windows.

### DIFF
--- a/tasks/section-config-runner-windows.yml
+++ b/tasks/section-config-runner-windows.yml
@@ -1,0 +1,5 @@
+---
+- include: line-config-runner-windows.yml
+  loop: "{{ gitlab_runner.extra_configs[section] | list }}"
+  loop_control:
+    loop_var: line

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -288,7 +288,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- include: section-config-runner.yml
+- include: section-config-runner-windows.yml
   loop: "{{ gitlab_runner.extra_configs|list }}"
   loop_control:
     loop_var: section


### PR DESCRIPTION
Hi,

when targeting Windows, there is a Linux-only include that cause the "Ensure section exists" task to run on the Windows target. Which of course simply stalls and never works.

This PR fixes this issue.