### PR TITLE
Fix missing [[runners]] section on Windows.

### DIFF
--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -1,4 +1,11 @@
 ---
+- name: (Windows) Print "[[runners]]" section
+  win_lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    line: '[[runners]]'
+    state: present
+    insertbefore: BOF
+
 - name: (Windows) Set concurrent limit option
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"


### PR DESCRIPTION
Hi,

the generated `config.toml` is missing the `[[runners]]` section because:

* its removed by the `split()` [here](https://github.com/riemers/ansible-gitlab-runner/blob/master/tasks/config-runners-windows.yml#L13)
* its never reprinted in the temporary file created for each runner

As a result, the call to `gitlab-runner.exe verify` fails with the following error:

```
FATAL: Near line 32 (last key parsed 'runners'): Key 'runners.custom_build_dir' has already been defined.
```

This PR fixes that issue.