### PR TITLE
Add support for Windows user account when installing the service.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,12 @@ gitlab_runner_sentry_dsn: ''
 # Prometheus Metrics & Monitoring
 gitlab_runner_listen_address: ''
 
+# The credentials for the Windows user used to run the gitlab-runner service.
+# Those credentials will be passed to `gitlab-runner.exe install`.
+# https://docs.gitlab.com/runner/install/windows.html 
+gitlab_runner_windows_service_user: ''
+gitlab_runner_windows_service_password: ''
+
 # A list of runners to register and configure
 gitlab_runner_runners:
     # The identifier of the runner.

--- a/tasks/install-windows.yml
+++ b/tasks/install-windows.yml
@@ -37,6 +37,15 @@
       win_command: "{{ gitlab_runner_executable }} install"
       args:
         chdir: "{{ gitlab_runner_config_file_location }}"
+      when: (gitlab_runner_windows_service_user | length == 0) or (gitlab_runner_windows_service_password | length == 0)
+    
+    - name: (Windows) Install GitLab Runner
+      win_command: "{{ gitlab_runner_executable }} install --user \"{{ gitlab_runner_windows_service_user }}\" --password \"{{ gitlab_runner_windows_service_password }}\""
+      args:
+        chdir: "{{ gitlab_runner_config_file_location }}"
+      when:
+        - gitlab_runner_windows_service_user | length > 0
+        - gitlab_runner_windows_service_password | length > 0
 
   when: (not gitlab_runner_exists)
 


### PR DESCRIPTION
Hi,

per the following documentation:

https://docs.gitlab.com/runner/install/windows.html#troubleshooting

the `--user` and `--password` options can be specified to install the Windows service for a specific user account.

This PR adds two new variables to do just that:

* `gitlab_runner_windows_service_user`
* `gitlab_runner_windows_service_password`

This is important because running with the `SYSTEM` account has limitations, especially if you rely on the `virtualbox` executor: the base images won't be found.