### PR TITLE
Make cache_s3_access_key optional

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -76,8 +76,12 @@
     {% endif %}
     {% if gitlab_runner.cache_s3_server_address is defined %}
     --cache-s3-server-address '{{ gitlab_runner.cache_s3_server_address }}'
+    {% if gitlab_runner.cache_s3_access_key is defined %}
     --cache-s3-access-key '{{ gitlab_runner.cache_s3_access_key }}'
+    {% endif %}
+    {% if gitlab_runner.cache_s3_secret_key is defined %}
     --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
+    {% endif %}
     {% endif %}
     {% if gitlab_runner.cache_s3_bucket_name is defined %}
     --cache-s3-bucket-name '{{ gitlab_runner.cache_s3_bucket_name }}'


### PR DESCRIPTION
Use s3 cache without explicit cache_s3_access_key in order to use IAM
instance profiles to authenticate on s3.