### PR TITLE
Adds the ability to specify the container network

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,8 @@ gitlab_runner_runners:
     docker_privileged: false
     # Runner Locked. When a runner is locked, it cannot be assigned to other projects
     locked: 'false'
+    # Add container to a custom network
+    docker_network_mode: bridge
     # Custom environment variables injected to build environment
     env_vars: []
     # Sets the clone_url. The default is not set.

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -172,6 +172,19 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
+- name: Set runner docker network option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*network_mode ='
+    line: '    network_mode = {{ gitlab_runner.docker_network_mode|default("bridge") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.docker_network_mode is defined else 'absent' }}"
+    insertafter: '^\s*\[runners\.docker\]'
+    backrefs: no
+  check_mode: no
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
+
 
 #### [runners.cache] section ####
 - name: Set cache section


### PR DESCRIPTION
This adds the ability to specify the networking mode of the container. I have intentionally kept the default in this role the same as the default in Gitlab/Docker.

It is mentioned [here](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersdocker-section) although undocumented.