### PR TITLE
fix removing global options when need to re register runner

### DIFF
--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -10,9 +10,6 @@
   import_tasks: install-macos.yml
   when: ansible_os_family == 'Darwin'
 
-- name: Set global options (macOS/Debian/RedHat)
-  import_tasks: global-setup.yml
-
 - name: (Unix) List configured runners
   command: "{{ gitlab_runner_executable }} list"
   register: configured_runners
@@ -35,6 +32,9 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
+
+- name: Set global options (macOS/Debian/RedHat)
+  import_tasks: global-setup.yml
 
 - name: (Unix) Configure GitLab Runner
   import_tasks: config-runners.yml


### PR DESCRIPTION
PROBLEM:
global option will is overwritten after runner need registration again, or if config file was deleted

HOW TO REPLCIATE:
- deregister and remove runner from gitlab without removing actual runner 
- rerun playbook again 
- check that global options like concurrency or listen-address is removed from config

FIX:
move setting of global option after registration of worker