### PR TITLE
Remove .bash_logout for both Debian Buster and Ubuntu Focal

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -31,17 +31,17 @@
   become: true
   environment:
     GITLAB_RUNNER_DISABLE_SKEL: "true"
-  when: ansible_distribution_version == "10"
+  when: ansible_distribution_release in ["buster", "focal"]
 
 - name: (Debian) Install GitLab Runner
   apt:
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
   become: true
-  when: ansible_distribution_version != "10"
+  when: ansible_distribution_release not in ["buster", "focal"]
 
-- name: (Debian) Remove ~/gitlab-runner/.bash_logout on debian buster
+- name: (Debian) Remove ~/gitlab-runner/.bash_logout on debian buster and ubuntu focal
   file:
     path: /home/gitlab-runner/.bash_logout
     state: absent
-  when: ansible_distribution_version == "10"
+  when: ansible_distribution_release in ["buster", "focal"]


### PR DESCRIPTION
First attempt to fix #137 

I've created a conditional on `when: ansible_distribution_release in ["buster", "focal"]`

If you want to be more specific we can make it conditional on `ansible_distribution` and `ansible_distribution_release`.... or other OS data. 

If future releases of both distros are going to create `.bash_logout` then we might want to move the list of relevant releases into `vars/Debian.yml`

Feedback welcome!