### PR TITLE
Support runner-specific coordinator url

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,14 @@ Example Playbook
 
 Inside `vars/main.yml`
 ```yaml
-gitlab_runner_registration_token: 'HUzTMgnxk17YV8Rj8ucQ'
+gitlab_runner_coordinator_url: https://gitlab.com
+gitlab_runner_registration_token: '12341234'
 gitlab_runner_runners:
   - name: 'Example Docker GitLab Runner'
     # token is an optional override to the global gitlab_runner_registration_token
-    token: 'HUzTMgnxk17YV8Rj8ucQ'
+    token: 'abcd'
+    # url is an optional override to the global gitlab_runner_coordinator_url
+    url: 'https://my-own-gitlab.mydomain.com'
     executor: docker
     docker_image: 'alpine'
     tags:

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -23,7 +23,7 @@
   win_shell: >
     {{ gitlab_runner_executable }} register
     --non-interactive
-    --url '{{ gitlab_runner_coordinator_url }}'
+    --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
     --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
     --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -27,7 +27,7 @@
   command: >
     {{ gitlab_runner_executable }} register
     --non-interactive
-    --url '{{ gitlab_runner_coordinator_url }}'
+    --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
     --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
     --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'


### PR DESCRIPTION
Issue #145.

For users having multiple Gitlab instances (such as during migration between systems), it is highly beneficial to connect the same runner instance to multiple Gitlabs. Currently, only a single global coordinator url is supported.

This PR enables configuring runner-specific url in vars and using that when registering the runner. 