### PR TITLE
feat: configure runner shell if defined

### DIFF
--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -34,6 +34,9 @@
     --run-untagged
     {% endif %}
     --executor '{{ gitlab_runner.executor|default("shell") }}'
+    {% if gitlab_runner.shell is defined %}
+    --shell '{{ gitlab_runner.shell }}'
+    {% endif %}
     --limit '{{ gitlab_runner.concurrent_specific|default(0) }}'
     --output-limit '{{ gitlab_runner.output_limit|default(4096) }}'
     --locked='{{ gitlab_runner.locked|default(false) }}'

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -38,6 +38,9 @@
     --run-untagged
     {% endif %}
     --executor '{{ gitlab_runner.executor|default("shell") }}'
+    {% if gitlab_runner.shell is defined %}
+    --shell '{{ gitlab_runner.shell }}'
+    {% endif %}
     --limit '{{ gitlab_runner.concurrent_specific|default(0) }}'
     --output-limit '{{ gitlab_runner.output_limit|default(4096) }}'
     --locked='{{ gitlab_runner.locked|default(false) }}'

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -98,6 +98,17 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
+- name: (Windows) Set runner shell option
+  win_lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*shell =.*'
+    line: '  shell = {{ gitlab_runner.shell|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.shell is defined else 'absent' }}"
+    insertafter: '^\s*executor ='
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner_windows
+
 - name: (Windows) Set output_limit option
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -107,6 +107,19 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
+- name: Set runner shell option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*shell ='
+    line: '  shell = {{ gitlab_runner.shell|default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.shell is defined else 'absent' }}"
+    insertafter: '^\s*executor ='
+    backrefs: no
+  check_mode: no
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
+
 - name: Set runner executor section
   lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/tests/vars/Windows.yml
+++ b/tests/vars/Windows.yml
@@ -5,6 +5,22 @@ gitlab_runner_runners:
       - shell
     executor: shell
     state: present
+  - name: "Shell Bash Runner"
+    tags:
+      - windows
+      - shell
+      - bash
+    executor: shell
+    shell: bash
+    state: present
+  - name: "Shell Cmd Runner"
+    tags:
+      - windows
+      - shell
+      - cmd
+    executor: shell
+    shell: cmd
+    state: present
   - name: "Shell Runner S3 Cache"
     tags:
       - windows

--- a/tests/vars/default.yml
+++ b/tests/vars/default.yml
@@ -6,6 +6,11 @@ gitlab_runner_runners:
       - node
       - ruby
       - mysql
+  - name: 'vagrant-shell-sh'
+    executor: shell
+    shell: sh
+    tags:
+      - sh
   - name: 'vagrant-docker'
     executor: docker
     docker_image: 'docker:stable'


### PR DESCRIPTION
Not to be confused with the shell executor, this configures the shell that will be used to execute the script steps inside running jobs. Mostly useful for windows, where people might want either cmd/powershell, or bash for more portable build scripts.

See https://docs.gitlab.com/runner/shells/.

Let me know if there's anything weird in this.