### PR TITLE
Add an option to skip the repository installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ On Linux, use `gitlab_runner_package_version` instead.
   + `gitlab_runner_cache_s3_bucket_location`
   + `gitlab_runner_cache_s3_insecure`
   + `gitlab_runner_cache_cache_shared`
+- `gitlab_runner_skip_package_repo_install`- Skip the APT or YUM repository installation (by default, false). You should provide a repository containing the needed packages before running this role.
 
 ## Autoscale Runner Machine vars for AWS (optional)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,11 @@ gitlab_runner_sentry_dsn: ''
 # Prometheus Metrics & Monitoring
 gitlab_runner_listen_address: ''
 
+# Skip the APT or YUM repository installation
+# You should provide a repository containing the needed packages before running this role.
+# Use this if you use a mirror repository
+# gitlab_runner_skip_package_repo_install: true
+
 # The credentials for the Windows user used to run the gitlab-runner service.
 # Those credentials will be passed to `gitlab-runner.exe install`.
 # https://docs.gitlab.com/runner/install/windows.html 

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -5,12 +5,14 @@
     url: "https://packages.gitlab.com/install/repositories/runner/{{ gitlab_runner_package_name }}/script.deb.sh"
     dest: /tmp/gitlab-runner.script.deb.sh
     mode: 0744
+  when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 
 - name: (Debian) Install Gitlab repository
   command: bash /tmp/gitlab-runner.script.deb.sh
   args:
     creates: "/etc/apt/sources.list.d/runner_{{ gitlab_runner_package_name }}.list"
   become: true
+  when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 
 - name: (Debian) Update gitlab_runner_package_name
   set_fact:

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -5,6 +5,7 @@
     url: "https://packages.gitlab.com/install/repositories/runner/{{ gitlab_runner_package_name }}/script.rpm.sh"
     dest: /tmp/gitlab-runner.script.rpm.sh
     mode: 0744
+  when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 
 - name: (RedHat) Install Gitlab repository
   shell: >
@@ -13,6 +14,7 @@
   args:
     creates: "/etc/yum.repos.d/runner_{{ gitlab_runner_package_name }}.repo"
   become: true
+  when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 
 - name: (RedHat) Update gitlab_runner_package_name
   set_fact:


### PR DESCRIPTION
Add the ability to skip the repository installation on servers isolated from internet and/or behind a proxy repository such as Nexus or Artifactory.
A repository with all the required packages should be configured before using this option.
By default, no behavior changes.