### PR TITLE
Support reloading gitlab under systemd instead of restarting

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 # non macOS
 - name: restart_gitlab_runner
-  service: name=gitlab-runner state=restarted
+  service: name=gitlab-runner state={{ gitlab_runner_restart_state }}
   become: yes
   when: ansible_os_family != 'Darwin' and ansible_os_family != 'Windows' and not gitlab_runner_container_install
 
@@ -19,7 +19,7 @@
 
 # Container
 - name: restart_gitlab_runner_container
-  docker_container: 
+  docker_container:
     name: "{{ gitlab_runner_container_name }}"
     restart: yes
   when: gitlab_runner_container_install

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -33,3 +33,35 @@
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
   become: true
+
+- name: Ensure /etc/systemd/system/gitlab-runner.service.d/ exists
+  file:
+    path: /etc/systemd/system/gitlab-runner.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Add reload command to GitLab Runner system service
+  copy:
+    dest: /etc/systemd/system/gitlab-runner.service.d/exec-reload.conf
+    content: |
+      [Service]
+      ExecReload=/bin/kill -HUP $MAINPID
+  register: gitlab_runner_exec_reload
+
+# https://docs.gitlab.com/runner/configuration/init.html#overriding-systemd
+- name: Configure graceful stop for GitLab Runner system service
+  copy:
+    dest: /etc/systemd/system/gitlab-runner.service.d/kill.conf
+    content: |
+      [Service]
+      TimeoutStopSec={{ gitlab_runner_timeout_stop_seconds }}
+      KillSignal=SIGQUIT
+  when: gitlab_runner_timeout_stop_seconds > 0
+  register: gitlab_runner_kill_timeout
+
+- name: Force systemd to reread configs
+  systemd:
+    daemon_reload: yes
+  when: gitlab_runner_exec_reload.changed or gitlab_runner_kill_timeout

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,3 +4,5 @@ gitlab_runner_executable: "/usr/bin/{{ gitlab_runner_package_name }}"
 
 gitlab_runner_runtime_owner: gitlab-runner
 gitlab_runner_runtime_group: gitlab-runner
+gitlab_runner_restart_state: reloaded
+gitlab_runner_timeout_stop_seconds: 7200

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -3,3 +3,4 @@ gitlab_runner_container_install: false
 gitlab_runner_container_image: gitlab/gitlab-runner
 gitlab_runner_container_tag: latest
 gitlab_runner_container_name: gitlab-runner
+gitlab_runner_restart_state: restarted


### PR DESCRIPTION
Restarting a runner without `SIGQUIT` will cause the runner to immediately cancel all jobs, and restart, which is quite undesirable. Instead, on systemd based systems (only implemented for Red Hat derivatives currently), we should configure systemd to use `SIGHUP` to reload when the configuration changes, and `SIGQUIT` before stopping/restarting to ensure gitlab waits for jobs to complete before stopping. The timeout to wait before forcefully killing the process to restart can be configured with `gitlab_runner_timeout_stop_seconds`. 

