### PR TITLE
Support systemd reloading on debian too

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -47,3 +47,6 @@
     path: /home/gitlab-runner/.bash_logout
     state: absent
   when: ansible_distribution_release in ["buster", "focal"]
+
+- name: Set systemd reload options
+  import_tasks: systemd-reload.yml

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -34,34 +34,5 @@
     state: "{{ gitlab_runner_package_state }}"
   become: true
 
-- name: Ensure /etc/systemd/system/gitlab-runner.service.d/ exists
-  file:
-    path: /etc/systemd/system/gitlab-runner.service.d
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-
-- name: Add reload command to GitLab Runner system service
-  copy:
-    dest: /etc/systemd/system/gitlab-runner.service.d/exec-reload.conf
-    content: |
-      [Service]
-      ExecReload=/bin/kill -HUP $MAINPID
-  register: gitlab_runner_exec_reload
-
-# https://docs.gitlab.com/runner/configuration/init.html#overriding-systemd
-- name: Configure graceful stop for GitLab Runner system service
-  copy:
-    dest: /etc/systemd/system/gitlab-runner.service.d/kill.conf
-    content: |
-      [Service]
-      TimeoutStopSec={{ gitlab_runner_timeout_stop_seconds }}
-      KillSignal=SIGQUIT
-  when: gitlab_runner_timeout_stop_seconds > 0
-  register: gitlab_runner_kill_timeout
-
-- name: Force systemd to reread configs
-  systemd:
-    daemon_reload: yes
-  when: gitlab_runner_exec_reload.changed or gitlab_runner_kill_timeout
+- name: Set systemd reload options
+  import_tasks: systemd-reload.yml

--- a/tasks/systemd-reload.yml
+++ b/tasks/systemd-reload.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Ensure /etc/systemd/system/gitlab-runner.service.d/ exists
+  file:
+    path: /etc/systemd/system/gitlab-runner.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Add reload command to GitLab Runner system service
+  copy:
+    dest: /etc/systemd/system/gitlab-runner.service.d/exec-reload.conf
+    content: |
+      [Service]
+      ExecReload=/bin/kill -HUP $MAINPID
+  register: gitlab_runner_exec_reload
+
+# https://docs.gitlab.com/runner/configuration/init.html#overriding-systemd
+- name: Configure graceful stop for GitLab Runner system service
+  copy:
+    dest: /etc/systemd/system/gitlab-runner.service.d/kill.conf
+    content: |
+      [Service]
+      TimeoutStopSec={{ gitlab_runner_timeout_stop_seconds }}
+      KillSignal=SIGQUIT
+  when: gitlab_runner_timeout_stop_seconds > 0
+  register: gitlab_runner_kill_timeout
+
+- name: Force systemd to reread configs
+  systemd:
+    daemon_reload: yes
+  when: gitlab_runner_exec_reload.changed or gitlab_runner_kill_timeout

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,3 +4,5 @@ gitlab_runner_executable: "/usr/bin/{{ gitlab_runner_package_name }}"
 
 gitlab_runner_runtime_owner: gitlab-runner
 gitlab_runner_runtime_group: gitlab-runner
+gitlab_runner_restart_state: reloaded
+gitlab_runner_timeout_stop_seconds: 720


### PR DESCRIPTION
The debian runner installation also has a compatible systemd unit for
reloading. This moves systemd-reload setup into a new file and enables
it for debian and redhat.