### PR TITLE
Fix - Running role second time corrupts config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,26 @@ On Linux, use `gitlab_runner_package_version` instead.
 - `gitlab_runner_coordinator_url` - The GitLab coordinator URL. Defaults to `https://gitlab.com`.
 - `gitlab_runner_sentry_dsn` - Enable tracking of all system level errors to Sentry
 - `gitlab_runner_listen_address` - Enable `/metrics` endpoint for Prometheus scraping.
-- `gitlab_runner_runners` - A list of gitlab runners to register & configure. Defaults to a single shell executor. See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file listing all possible options which you can be passed to a runner registration command.
-- `gitlab_runner_cache_type` - Variables to set s3 as a shared cache server. If set it requires variables listed below:
-  + `gitlab_runner_cache_s3_server_address`
-  + `gitlab_runner_cache_s3_access_key`
-  + `gitlab_runner_cache_s3_access_key`
-  + `gitlab_runner_cache_s3_bucket_name`
-  + `gitlab_runner_cache_s3_bucket_location`
-  + `gitlab_runner_cache_s3_insecure`
-  + `gitlab_runner_cache_cache_shared`
+- `gitlab_runner_runners` - A list of gitlab runners to register & configure. Defaults to a single shell executor.
 - `gitlab_runner_skip_package_repo_install`- Skip the APT or YUM repository installation (by default, false). You should provide a repository containing the needed packages before running this role.
+
+See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file listing all possible options which you can be passed to a runner registration command.
+
+### Gitlab Runners cache
+For each gitlab runner in gitlab_runner_runners you can set cache options. At the moment role support s3 or gcs types.
+Example configurration for s3 can be:
+```yaml
+gitlab_runner_runners:
+  cache_type: "s3"
+  cache_path: "cache"
+  cache_shared: true
+  cache_s3_server_address: "s3.amazonaws.com"
+  cache_s3_access_key: "<access_key>"
+  cache_s3_secret_key: "<secret_key>"
+  cache_s3_bucket_name: "<bucket_name>
+  cache_s3_bucket_location: "eu-west-1"
+  cache_s3_insecure: false
+```
 
 ## Autoscale Runner Machine vars for AWS (optional)
 

--- a/tasks/line-config-runner-windows.yml
+++ b/tasks/line-config-runner-windows.yml
@@ -9,6 +9,6 @@
   win_lineinfile:
     path: "{{ temp_runner_config.path }}"
     insertafter: '\s+\[{{ section | regex_escape }}\]'
-    regexp: '^(\s*){{ line|regex_escape }} =.*'
+    regexp: '^(\s*){{ line | to_json | regex_escape }} =.*'
     line: '{{ "  " * (section.split(".")|length) }}{{ line | to_json }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
   register: modified_config_line

--- a/tasks/line-config-runner.yml
+++ b/tasks/line-config-runner.yml
@@ -9,6 +9,6 @@
   lineinfile:
     path: "{{ temp_runner_config.path }}"
     insertafter: '\s+\[{{ section | regex_escape }}\]'
-    regexp: '^(\s*){{ line|regex_escape }} ='
+    regexp: '^(\s*){{ line | to_json | regex_escape }} ='
     line: '{{ "  " * (section.split(".")|length) }}{{ line | to_json }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
   register: modified_config_line


### PR DESCRIPTION
The problem was in line-config-runner-windows.yml with regexp.

In PR https://github.com/riemers/ansible-gitlab-runner/issues/153 We have added to_json to the "line" parameter and parameters stopped to match regexp:
Before:
```
  [runners.docker]
    cpus = "4"
    volumes = ["/certs/client", "/cache"]
    privileged = true
    memory = "8g"
```
After:
```
  [runners.docker]
    "cpus" = "4"
    "volumes" = ["/certs/client", "/cache"]
    "privileged" = true
    "memory" = "8g"
```

I've fixed regexp to match with lines.

-------------

Also, updated cache section update in Readme.
The previous one doesn't match with a code.