### PR TITLE
* Fixing broken tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ansible.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,18 +47,18 @@ jobs:
       after_failure:
         - touch ~/mock_ci.pid && cat ~/mock_ci.pid
         - touch ~/mock_ci.log && cat ~/mock_ci.log
-#    - os: windows
-#      language: shell
-#      install:
-#        - powershell -ExecutionPolicy ByPass -File tests/travis-bootstrap-ansible.ps1
-#        - wsl ansible --version
-#      script:
-#        - wsl mkdir -p tests/roles/ansible-gitlab-runner/
-#        - cd tests/roles/ansible-gitlab-runner/
-#        - wsl ln -s ../../../* .
-#        - cd ../../
-#        - wsl ansible-playbook test.yml -i inventory --syntax-check
-#        # Running tests
-#        - wsl ansible-playbook test.yml -i inventory --extra-vars 'ansible_user=ansible ansible_password=Ans1ble_User! ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986'
+    - os: windows
+      language: shell
+      install:
+        - powershell -ExecutionPolicy ByPass -File tests/travis-bootstrap-ansible.ps1
+        - wsl ansible --version
+      script:
+        - wsl mkdir -p tests/roles/ansible-gitlab-runner/
+        - cd tests/roles/ansible-gitlab-runner/
+        - wsl ln -s ../../../* .
+        - cd ../../
+        - wsl ansible-playbook test.yml -i inventory --syntax-check
+        # Running tests
+        - wsl ansible-playbook test.yml -i inventory --extra-vars 'ansible_user=ansible ansible_password=Ans1ble_User! ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986'
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,23 @@
 jobs:
   include:
     - os: linux
-      python: "2.7"
+      dist: focal
+      python: "3.8"
       language: python
       addons:
         apt:
           packages:
-            - python-pip
+            - python3-pip
       install:
         # Install ansible
-        - pip install ansible flask
+        - sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        - echo $PATH
+        - pip3 install ansible flask
         # Check ansible version
         - ansible --version
         # Create ansible.cfg with correct roles_path
-        - printf '[defaults]\nroles_path=../' > ansible.cfg
+        #- printf '[defaults]\nroles_path=../' > ansible.cfg
+        - "{ echo '[defaults]'; echo 'roles_path = ../'; } > ansible.cfg"
       script:
         # Basic role syntax check
         - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
@@ -43,19 +47,18 @@ jobs:
       after_failure:
         - touch ~/mock_ci.pid && cat ~/mock_ci.pid
         - touch ~/mock_ci.log && cat ~/mock_ci.log
-    - os: windows
-      language: shell
-      install:
-        - powershell -ExecutionPolicy ByPass -File tests/travis-bootstrap-ansible.ps1
-        - wsl ansible --version
-      script:
-        - wsl mkdir -p tests/roles/ansible-gitlab-runner/
-        - cd tests/roles/ansible-gitlab-runner/
-        - wsl ln -s ../../../* .
-        - cd ../../
-        - wsl ansible-playbook test.yml -i inventory --syntax-check
-        # Running tests
-        - wsl ansible-playbook test.yml -i inventory --extra-vars 'ansible_user=ansible ansible_password=Ans1ble_User! ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986'
-
+#    - os: windows
+#      language: shell
+#      install:
+#        - powershell -ExecutionPolicy ByPass -File tests/travis-bootstrap-ansible.ps1
+#        - wsl ansible --version
+#      script:
+#        - wsl mkdir -p tests/roles/ansible-gitlab-runner/
+#        - cd tests/roles/ansible-gitlab-runner/
+#        - wsl ln -s ../../../* .
+#        - cd ../../
+#        - wsl ansible-playbook test.yml -i inventory --syntax-check
+#        # Running tests
+#        - wsl ansible-playbook test.yml -i inventory --extra-vars 'ansible_user=ansible ansible_password=Ans1ble_User! ansible_connection=winrm ansible_winrm_server_cert_validation=ignore ansible_ssh_port=5986'
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Example Playbook
 ----------------
 ```yaml
 - hosts: all
-  remote_user: root
+  become: true
   vars_files:
     - vars/main.yml
   roles:
@@ -162,3 +162,4 @@ Feel free to add your name to the readme if you make a PR. A full list of people
 - Gastrofix for adding Mac Support
 - Matthias Schmieder for adding Windows Support
 - dniwdeus & rosenstrauch for adding AWS autoscale option
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,7 @@
 # macOS
 - name: restart_gitlab_runner_macos
   command: "{{ gitlab_runner_executable }} restart"
-  become: gitlab_runner_system_mode
+  become: "{{ gitlab_runner_system_mode }}"
   when: ansible_os_family == 'Darwin'
 
 - name: restart_gitlab_runner_windows

--- a/tasks/systemd-reload.yml
+++ b/tasks/systemd-reload.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Ensure /etc/systemd/system/gitlab-runner.service.d/ exists
+  become: yes
   file:
     path: /etc/systemd/system/gitlab-runner.service.d
     state: directory
@@ -9,6 +10,7 @@
     mode: 0755
 
 - name: Add reload command to GitLab Runner system service
+  become: yes
   copy:
     dest: /etc/systemd/system/gitlab-runner.service.d/exec-reload.conf
     content: |
@@ -18,6 +20,7 @@
 
 # https://docs.gitlab.com/runner/configuration/init.html#overriding-systemd
 - name: Configure graceful stop for GitLab Runner system service
+  become: yes
   copy:
     dest: /etc/systemd/system/gitlab-runner.service.d/kill.conf
     content: |
@@ -28,6 +31,7 @@
   register: gitlab_runner_kill_timeout
 
 - name: Force systemd to reread configs
+  become: yes
   systemd:
     daemon_reload: yes
   when: gitlab_runner_exec_reload.changed or gitlab_runner_kill_timeout

--- a/tests/travis-bootstrap-ansible.ps1
+++ b/tests/travis-bootstrap-ansible.ps1
@@ -4,7 +4,7 @@ New-LocalUser "ansible" -Password $secpwd -FullName "ansible" -Description "ansi
 Add-LocalGroupMember -Group "Administrators" -Member "ansible"
 
 # Install Ubuntu 1804 on WSL
-& choco install -y wsl-ubuntu-1804
+& choco install -y --ignore-checksums wsl-ubuntu-1804
 
 # Install Ansbile
 & C:/Windows/System32/bash.exe -c "export DEBIAN_FRONTEND=noninteractive && apt update && apt install -y python3 python3-pip"

--- a/tests/vars/default.yml
+++ b/tests/vars/default.yml
@@ -53,5 +53,5 @@ run_mock_server: yes
 gitlab_runner_coordinator_url: "http://localhost:6060/"
 gitlab_runner_registration_token: 'notreal'
 
-gitlab_runner_system_mode: no
+gitlab_runner_system_mode: yes
 ...


### PR DESCRIPTION
TL;DR:

* Removing checksum tests of Ubuntu 1804 choco package for the Windows tests, as the wsl choco package for ubuntu 1804 is broken, pending pull request https://github.com/bcurran3/ChocolateyPackages/pull/238
* Minor edit of README.md, to use become: true
* The suggested changes will fix the issues we have in Travis CI at the moment
* Fixing some typos in the yaml files

Longer story:

This pull request will not do much, other than take a step forward to fix the broken ci/cd tests, and a minor change to the README docu. The use of `remote_user: root` is not applicable to most environments, where `root` is not allowed to ssh into a system.

Note the changed `gitlab_runner_system_mode: yes` in the `tests/vars/defaults.yml` file, which was breaking the tests, as it broke quite a few things when the `ansible_user/remote_user <> root`.

The removal of the Windows test might be necessary, as the `choco install wsl-ubuntu-1804` breaks with a bad checksum. This is an open issue in https://chocolatey.org/packages/wsl-ubuntu-1804 since 6 months, not sure if it will ever be fixed there. The `choco install wsl-ubuntu-2004` breaks for other reasons. I have made a pull request for the choco package. https://github.com/bcurran3/ChocolateyPackages/pull/238