### PR TITLE
extra runner config options

### DIFF
--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -39,6 +39,19 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
+- name: Add log_format to config
+  lineinfile:
+    dest: "{{ gitlab_runner_config_file }}"
+    regexp: '^log_format ='
+    line: 'log_format = "{{ gitlab_runner_log_format }}"'
+    insertafter: '\s*listen_address.*'
+    state: present
+  when: gitlab_runner_log_format | length > 0  # Ensure value is set
+  become: "{{ gitlab_runner_system_mode }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
+
 - name: Add sentry dsn to config
   lineinfile:
     dest: "{{ gitlab_runner_config_file }}"

--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -57,6 +57,15 @@
       {% if gitlab_runner.docker_dns|default(false) %}
       --docker-dns '{{ gitlab_runner.docker_dns|default("1.1.1.1") }}'
       {% endif %}
+      {% if gitlab_runner.docker_dns_search|default(false) %}
+      --docker-dns-search '{{ gitlab_runner.docker_dns_search|default([]) }}'
+      {% endif %}
+      {% if gitlab_runner.docker_disable_cache|default(false) %}
+      --docker-disable-cache
+      {% endif %}
+      {% if gitlab_runner.docker_oom_kill_disable|default(false) %}
+      --docker-oom-kill-disable '{{ gitlab_runner.docker_oom_kill_disable|default("false") }}'
+      {% endif %}
       {% for volume in gitlab_runner.docker_volumes | default([]) %}
       --docker-volumes "{{ volume }}"
       {% endfor %}

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -66,7 +66,16 @@
     {% if gitlab_runner.docker_dns|default(false) %}
     --docker-dns '{{ gitlab_runner.docker_dns|default("1.1.1.1") }}'
     {% endif %}
-    {% for volume in gitlab_runner.docker_volumes | default([]) %}
+    {% if gitlab_runner.docker_dns_search|default(false) %}
+    --docker-dns-search '{{ gitlab_runner.docker_dns_search|default([]) }}'
+    {% endif %}
+    {% if gitlab_runner.docker_disable_cache|default(false) %}
+    --docker-disable-cache
+    {% endif %}
+    {% if gitlab_runner.docker_oom_kill_disable|default(false) %}
+    --docker-oom-kill-disable '{{ gitlab_runner.docker_oom_kill_disable|default("false") }}'
+    {% endif %}
+    {% for volume in gitlab_runner.docker_volumes|default([]) %}
     --docker-volumes "{{ volume }}"
     {% endfor %}
     --ssh-user '{{ gitlab_runner.ssh_user|default("") }}'


### PR DESCRIPTION
In our environment we use some gitlab-runner config parameters that are not yet in this ansible role. Example:

```
log_format = "json"
[runners.docker]
disable_cache = false
dns_search = ["us-east-2.somedomain.tld"]
oom_kill_disable = true
```

This PR aims to add those options. 

