### PR TITLE
Revert "install gitlab-runner on el8 from el7 repo"

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -8,9 +8,7 @@
   when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 
 - name: (RedHat) Install Gitlab repository
-  shell: >
-    os=el dist={{ '7' if ansible_distribution_major_version | int == 8 else ansible_distribution_major_version }}
-    bash /tmp/gitlab-runner.script.rpm.sh
+  command: bash /tmp/gitlab-runner.script.rpm.sh
   args:
     creates: "/etc/yum.repos.d/runner_{{ gitlab_runner_package_name }}.repo"
   become: true


### PR DESCRIPTION
This reverts commit 55a423f84bed801f17ff79d2a56e84dd32761022.

There is no reason to enforce the el7 packages on el8 anymore, as el8 is now [fully supported](https://docs.gitlab.com/13.9/runner/install/linux-repository.html).

It also allows for overriding the el and dist environment variables, which is necessary when using this role on e.g. Amazon Linux