### PR TITLE
Add default value for gitlab_runner_log_format option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,9 @@ gitlab_runner_container_install: false
 # default state to restart
 gitlab_runner_restart_state: "restarted"
 
+# default value for log_format
+gitlab_runner_log_format: runner
+
 # A list of runners to register and configure
 gitlab_runner_runners:
     # The identifier of the runner.


### PR DESCRIPTION
This PR adds default value for `log_format` option. It will remove [this error](https://github.com/riemers/ansible-gitlab-runner/pull/165#issuecomment-787448997) if value is not set in vars.