### PR TITLE
"Modify existing line" regexp fix

### DIFF
--- a/tasks/line-config-runner-windows.yml
+++ b/tasks/line-config-runner-windows.yml
@@ -9,6 +9,6 @@
   win_lineinfile:
     path: "{{ temp_runner_config.path }}"
     insertafter: '\s+\[{{ section | regex_escape }}\]'
-    regexp: '^(\s*){{ line | to_json | regex_escape }} =.*'
+    regexp: '^(\s*)({{ line | to_json | regex_escape }}|{{ line | regex_escape }}) =.*'
     line: '{{ "  " * (section.split(".")|length) }}{{ line | to_json }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
   register: modified_config_line

--- a/tasks/line-config-runner.yml
+++ b/tasks/line-config-runner.yml
@@ -9,6 +9,6 @@
   lineinfile:
     path: "{{ temp_runner_config.path }}"
     insertafter: '\s+\[{{ section | regex_escape }}\]'
-    regexp: '^(\s*){{ line | to_json | regex_escape }} ='
+    regexp: '^(\s*)({{ line | to_json | regex_escape }}|{{ line | regex_escape }}) ='
     line: '{{ "  " * (section.split(".")|length) }}{{ line | to_json }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
   register: modified_config_line


### PR DESCRIPTION
This PR fixes `key ... has already been defined` issue (like [here](https://github.com/riemers/ansible-gitlab-runner/issues/159)).  

The reason of this issue is adding `| to_json` filter in `lineinline` search regexp in [v1.6.25 release](https://github.com/riemers/ansible-gitlab-runner/compare/v1.6.24...v1.6.25). `| to_json` filter surrounds key with double quotes when searching for lines but existing keys could be without quotes, they are not found during modification and double keys appear (e.g. default `run_exec = ""` is not deleted for custom runners).  

Updated regexp allows to search for keys for both options (with and without quotes).