### PR TITLE
log_format placement

### DIFF
--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -39,12 +39,12 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
-- name: Add log_format to config
+- name: Add log_format to config 
   lineinfile:
     dest: "{{ gitlab_runner_config_file }}"
     regexp: '^log_format ='
-    line: 'log_format = "{{ gitlab_runner_log_format }}"'
-    insertafter: '\s*listen_address.*'
+    line: 'log_format = "{{ gitlab_runner_log_format|default("runner") }}"'
+    insertbefore: BOF
     state: present
   when: gitlab_runner_log_format | length > 0  # Ensure value is set
   become: "{{ gitlab_runner_system_mode }}"


### PR DESCRIPTION
Based on feedback here:
https://github.com/riemers/ansible-gitlab-runner/pull/165 

- add default log format as type 'runner'
- Change the line placement to beginning of file as some users do not specify 'listen_address'