### PR TITLE
log_format only if var is defined

### DIFF
--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -46,7 +46,7 @@
     line: 'log_format = "{{ gitlab_runner_log_format|default("runner") }}"'
     insertbefore: BOF
     state: present
-  when: gitlab_runner_log_format | length > 0  # Ensure value is set
+  when: gitlab_runner_log_format is defined # Ensure value is set
   become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner


### PR DESCRIPTION
Amending to use is defined instead of length so that task only applies if the variable exists 
as discussed here:
https://github.com/riemers/ansible-gitlab-runner/pull/167