### PR TITLE
comment out log_format defaults as optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,7 @@ gitlab_runner_container_install: false
 gitlab_runner_restart_state: restarted
 
 # default value for log_format
-gitlab_runner_log_format: runner
+# gitlab_runner_log_format: runner
 
 # A list of runners to register and configure
 gitlab_runner_runners:


### PR DESCRIPTION
Previous PR changed 'length>0' to 'is defined' for the log_format parameter.
So we can comment out the log_format parameter in the defaults.yml as optional. 