### PR TITLE
fix for user mode install

### DIFF
--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -15,7 +15,7 @@
   register: configured_runners
   changed_when: False
   check_mode: no
-  become: yes
+  become: "{{ gitlab_runner_system_mode }}"
 
 - name: (Unix) Check runner is registered
   command: "{{ gitlab_runner_executable }} verify"
@@ -23,7 +23,7 @@
   ignore_errors: True
   changed_when: False
   check_mode: no
-  become: yes
+  become: "{{ gitlab_runner_system_mode }}"
 
 - name: (Unix) Register GitLab Runner
   include_tasks: register-runner.yml


### PR DESCRIPTION
submitting PR for issue mentioned here: https://github.com/riemers/ansible-gitlab-runner/issues/173

essentially, when installing gitlab-runner in user mode the tasks which list configured runners and check registered runners is currently looking at the config.toml in the system path and not the user path (defined in vars/main.yml)