### PR TITLE
bugfix: replaced lineinfile for win_lineinfile for windows deployment

### DIFF
--- a/tasks/global-setup-windows.yml
+++ b/tasks/global-setup-windows.yml
@@ -49,7 +49,7 @@
     - restart_gitlab_runner_windows
 
 - name: (Windows) Add session server listen_address to config
-  lineinfile:
+  win_lineinfile:
     dest: "{{ gitlab_runner_config_file }}"
     regexp: '^\s*listen_address ='
     line: '  listen_address = "{{ gitlab_runner_session_server_listen_address }}"'
@@ -61,7 +61,7 @@
     - restart_gitlab_runner_windows
 
 - name: (Windows) Add session server advertise_address to config
-  lineinfile:
+  win_lineinfile:
     dest: "{{ gitlab_runner_config_file }}"
     regexp: '^\s*advertise_address ='
     line: '  advertise_address = "{{ gitlab_runner_session_server_advertise_address }}"'
@@ -73,7 +73,7 @@
     - restart_gitlab_runner_windows
 
 - name: (Windows) Add session server session_timeout to config
-  lineinfile:
+  win_lineinfile:
     dest: "{{ gitlab_runner_config_file }}"
     regexp: '^\s*session_timeout ='
     line: "  session_timeout = {{ gitlab_runner_session_server_session_timeout }}"


### PR DESCRIPTION
This should fix the deployment to windows machines. 
(https://github.com/riemers/ansible-gitlab-runner/pull/160#issuecomment-795876599)
Developed with assumptions as I do not have a windows machine available to test with. 

