### PR TITLE
move default vars to default/main

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,13 @@ gitlab_runner_windows_service_password: ''
 # gitlab_runner_container_install
 gitlab_runner_container_install: false
 
+# default values for gitlab in container
+gitlab_runner_container_install: false
+gitlab_runner_container_image: gitlab/gitlab-runner
+gitlab_runner_container_tag: latest
+gitlab_runner_container_name: gitlab-runner
+gitlab_runner_container_restart_policy: unless-stopped 
+
 # default state to restart
 gitlab_runner_restart_state: restarted
 


### PR DESCRIPTION
vars/default.yml is not always loaded, since https://github.com/riemers/ansible-gitlab-runner/blob/5caa92463e00a8b9ed9fe0f94d2d56230fd4a79b/tasks/main.yml#L2-L11 does not load it, if a distribution or os_family is found.

Since these variables are independent of any distribution, they should go to defaults/main.yml

If they are not loaded or not defined https://github.com/riemers/ansible-gitlab-runner/blob/5caa92463e00a8b9ed9fe0f94d2d56230fd4a79b/tasks/Container.yml#L67 fails with `variable undefined`

IMHO vars/default.yml could be completely removed, but I don't know if there are any edge-cases where no distribution or os_family is found and the include_vars fails. 