### PR TITLE
added possibility to define a network for the containers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,10 @@ gitlab_runner_windows_service_password: ''
 # gitlab_runner_container_install
 gitlab_runner_container_install: false
 
+# you can define a network which the container connects to
+# this option uses network_mode, thus 'default' will use the first network found in docker network list
+gitlab_runner_container_network: default
+
 # default state to restart
 gitlab_runner_restart_state: restarted
 

--- a/tasks/Container.yml
+++ b/tasks/Container.yml
@@ -72,3 +72,4 @@
     - type: bind
       source: /var/run/docker.sock
       target: /var/run/docker.sock
+    network_mode: "{{ gitlab_runner_container_network }}"

--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -116,6 +116,7 @@
       target: /etc/gitlab-runner
     cleanup: yes
     auto_remove: yes
+    network_mode: "{{ gitlab_runner_container_network }}"
   when: (verified_runners.container.Output.find("Verifying runner... is removed") != -1) or
         ((configured_runners.container.Output.find('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) == -1) and
         (gitlab_runner.state|default('present') == 'present'))


### PR DESCRIPTION
By default the docker_container module uses the first network in `docker network list`. Often this is the bridge network, which is inferior to custom networks (see [docs.docker.com](https://docs.docker.com/network/bridge/)) and also is unable to lookup containers on the same host (The default Bridge-Network takes the DNS Configuration of the host, while the custom networks are able to lookup the containers via DNS). 

As it would be possible to enter several networks for a runner, with the `networks` parameter, i think this is overly complex, since it MUST be configured since no sane default is usable.

Instead I added a parameter for `network_mode` [docs.ansible.com](see (https://docs.ansible.com/ansible/latest/collections/community/docker/docker_container_module.html#parameter-network_mode)) which is `default` by default. In the `default` behavior it still uses the first network from `docker network ls` and thus doesn't break any current usecases, but allows to configure a single network explicitly.

The network MUST exist beforehand. I think it is out-of-scope for this role to setup docker-networks for the runners.