### PR TITLE
added docker_devices

### DIFF
--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -69,6 +69,9 @@
       {% for volume in gitlab_runner.docker_volumes | default([]) %}
       --docker-volumes "{{ volume }}"
       {% endfor %}
+      {% for device in gitlab_runner.docker_devices | default([]) %}
+      --docker-devices "{{ device }}"
+      {% endfor %}
       --ssh-user '{{ gitlab_runner.ssh_user|default("") }}'
       --ssh-host '{{ gitlab_runner.ssh_host|default("") }}'
       --ssh-port '{{ gitlab_runner.ssh_port|default("") }}'

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -59,6 +59,9 @@
     {% for volume in gitlab_runner.docker_volumes | default([]) %}
     --docker-volumes "{{ volume }}"
     {% endfor %}
+    {% for device in gitlab_runner.docker_devices | default([]) %}
+    --docker-devices "{{ device }}"
+    {% endfor %}
     {% if gitlab_runner.ssh_user is defined %}
     --ssh-user '{{ gitlab_runner.ssh_user }}'
     {% endif %}

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -78,6 +78,9 @@
     {% for volume in gitlab_runner.docker_volumes|default([]) %}
     --docker-volumes "{{ volume }}"
     {% endfor %}
+    {% for device in gitlab_runner.docker_devices|default([]) %}
+    --docker-devices "{{ device }}"
+    {% endfor %}
     --ssh-user '{{ gitlab_runner.ssh_user|default("") }}'
     --ssh-host '{{ gitlab_runner.ssh_host|default("") }}'
     --ssh-port '{{ gitlab_runner.ssh_port|default("") }}'

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -153,6 +153,17 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
+- name: (Windows) Set docker devices option
+  win_lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*devices =.*'
+    line: '  devices = {{ gitlab_runner.docker_devices|default([])|to_json }}'
+    state: "{{ 'present' if gitlab_runner.docker_devices is defined else 'absent' }}"
+    insertafter: '^\s*executor ='
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner_windows
+
 - name: (Windows) Set cache type option
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -213,6 +213,19 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
+- name: Set docker devices option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*devices ='
+    line: '    devices = {{ gitlab_runner.docker_devices|default([])|to_json }}'
+    state: "{{ 'present' if gitlab_runner.docker_devices is defined else 'absent' }}"
+    insertafter: '^\s*executor ='
+    backrefs: no
+  check_mode: no
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
+
 - name: Set runner docker network option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"


### PR DESCRIPTION
to enable the passthrough of specific devices (like the fuse device) to the docker runner, i adapted the volumes part. besides the problems i already had in the current upstream master version (https://github.com/riemers/ansible-gitlab-runner/issues/59#issuecomment-822018779) i have tested it successfully.
