### PR TITLE
remove vars/default.yaml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,9 +45,6 @@ gitlab_runner_session_server_session_timeout: 1800
 gitlab_runner_windows_service_user: ''
 gitlab_runner_windows_service_password: ''
 
-# gitlab_runner_container_install
-gitlab_runner_container_install: false
-
 # default values for gitlab in container
 gitlab_runner_container_install: false
 gitlab_runner_container_image: gitlab/gitlab-runner

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,6 @@
       files:
         - '{{ ansible_distribution }}.yml'
         - '{{ ansible_os_family }}.yml'
-        - default.yml
       paths:
         - 'vars'
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,7 +8,6 @@
           files:
             - '{{ ansible_distribution }}.yml'
             - '{{ ansible_os_family }}.yml'
-            - default.yml
           paths:
             - 'vars'
     - name: Copy the mock gitlab CI server

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,6 +1,0 @@
----
-gitlab_runner_container_install: false
-gitlab_runner_container_image: gitlab/gitlab-runner
-gitlab_runner_container_tag: latest
-gitlab_runner_container_name: gitlab-runner
-gitlab_runner_container_restart_policy: unless-stopped


### PR DESCRIPTION
Those variables were copied to `vars/main.yaml` in this PR: https://github.com/riemers/ansible-gitlab-runner/pull/179

We couldn't get the container installation to work because the `gitlab_runner_container_install` was always overwritten by `vars/main.yaml`. Deleting it helped and we can now use it like described in the [docs](https://github.com/riemers/ansible-gitlab-runner#example-playbook).