### PR TITLE
Fix runner-specific coordinator url in upate-config-runner

### DIFF
--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -21,7 +21,7 @@
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*url =.*'
-    line: '  url = {{ gitlab_runner_coordinator_url | to_json }}'
+    line: '  url = {{ gitlab_runner.url|default(gitlab_runner_coordinator_url) | to_json }}'
     state: present
     insertafter: '^\s*limit ='
     backrefs: no

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -16,7 +16,7 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*url ='
-    line: '  url = {{ gitlab_runner_coordinator_url | to_json }}'
+    line: '  url = {{ gitlab_runner.url|default(gitlab_runner_coordinator_url) | to_json }}'
     state: present
     insertafter: '^\s*limit ='
     backrefs: no


### PR DESCRIPTION
For users having multiple Gitlab instances (such as during migration between systems), it is beneficial to connect the same runner instance to multiple Gitlabs. 

This PR builds on https://github.com/riemers/ansible-gitlab-runner/pull/146, adding support for the coordinator-specific URL in config-building too, not only registering. Basically the previous PR is incomplete and this is required on top.. Not sure how I managed to make it work with the previous change only.

Related issue: https://github.com/riemers/ansible-gitlab-runner/issues/145.