### PR TITLE
[debian] apt update_cache before installing gitlab-runner

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -30,6 +30,7 @@
   apt:
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
+    update_cache: yes
   become: true
   environment:
     GITLAB_RUNNER_DISABLE_SKEL: "true"


### PR DESCRIPTION
When running the role in GitLab CI, at times I have gotten the following message and failure:

```
TASK [riemers.gitlab-runner : (Debian) Get Gitlab repository installation script] ***
changed: [1836]
TASK [riemers.gitlab-runner : (Debian) Install Gitlab repository] **************
changed: [1836]
TASK [riemers.gitlab-runner : (Debian) Update gitlab_runner_package_name] ******
skipping: [1836]
TASK [riemers.gitlab-runner : (Debian) Set gitlab_runner_package_name] *********
ok: [1836]
TASK [riemers.gitlab-runner : (Debian) Install GitLab Runner] ******************
fatal: [1836]: FAILED! => {"changed": false, "msg": "No package matching 'gitlab-runner' is available"}
```

I figured this could be fixed by updating the `apt` cache before installing the package. I have tested this a few times in CI, and, sure enough, it works well.