### PR TITLE
namespace container names running in the check mode

### DIFF
--- a/tasks/Container.yml
+++ b/tasks/Container.yml
@@ -5,7 +5,7 @@
 
 - name: (Container) List configured runners
   docker_container:
-    name: "{{ gitlab_runner_container_name }}"
+    name: "{{ gitlab_runner_container_name }}-list"
     image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
     command: list
     mounts:
@@ -22,7 +22,7 @@
 
 - name: (Container) Check runner is registered
   docker_container:
-    name: "{{ gitlab_runner_container_name }}"
+    name: "{{ gitlab_runner_container_name }}-check"
     image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
     command: verify
     mounts:


### PR DESCRIPTION
Previously, running the `--check` mode was deleting the `gitlab_runner_container_name` container leading to unexpected downtime. This change also shortens the downtime during deployments. 

