### PR TITLE
Fix listen_address regex overlap

### DIFF
--- a/tasks/global-setup-windows.yml
+++ b/tasks/global-setup-windows.yml
@@ -51,7 +51,7 @@
 - name: (Windows) Add session server listen_address to config
   win_lineinfile:
     dest: "{{ gitlab_runner_config_file }}"
-    regexp: '^\s*listen_address ='
+    regexp: '^(\s+)listen_address ='
     line: '  listen_address = "{{ gitlab_runner_session_server_listen_address }}"'
     insertafter: '^\s*\[session_server\]'
     state: "{{ 'present' if gitlab_runner_session_server_listen_address | length > 0 else 'absent' }}"

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -68,7 +68,7 @@
 - name: Add session server listen_address to config
   lineinfile:
     dest: "{{ gitlab_runner_config_file }}"
-    regexp: '^\s*listen_address ='
+    regexp: '^(\s+)listen_address ='
     line: '  listen_address = "{{ gitlab_runner_session_server_listen_address }}"'
     insertafter: '^\s*\[session_server\]'
     state: "{{ 'present' if gitlab_runner_session_server_listen_address | length > 0 else 'absent' }}"


### PR DESCRIPTION
closes https://github.com/riemers/ansible-gitlab-runner/issues/192

line with  `listen_address` in `session_server` section should have at least one  `space` symbol

btw. not sure about regex `capturing group - ()`  usage, it has been used inconsistently in this role.