### PR TITLE
fix: empty cache section

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -311,7 +311,7 @@
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.cache\]'
     line: '  [runners.cache]'
-    state: present
+    state: "{{ 'present' if gitlab_runner.cache_type is defined else 'absent' }}"
     insertafter: EOF
     backrefs: no
   check_mode: no


### PR DESCRIPTION
When not defining any `cache_type`, an empty cache section is created leading
to further configuration being misplaced:
```toml
[[runners]]
  [...]
  [runners.docker]
    volumes = ["/var/run/docker.sock:/var/run/docker.sock", "/cache", "/cache-ci:/cache-ci:rw"]
  [runners.cache]
    image = "alpine:latest"
    privileged = false
    [runners.docker.services_tmpfs]
      "/var/lib/mysql" = "rw,noexec"
```