### PR TITLE
Override RPM repo script parameters when installing on Rocky

### DIFF
--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -8,7 +8,11 @@
   when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 
 - name: (RedHat) Install Gitlab repository
-  command: bash /tmp/gitlab-runner.script.rpm.sh
+  command: >
+    {% if ansible_distribution == "Rocky" %}
+    env os=el dist={{ ansible_distribution_major_version }}
+    {% endif %}
+    bash /tmp/gitlab-runner.script.rpm.sh
   args:
     creates: "/etc/yum.repos.d/runner_{{ gitlab_runner_package_name }}.repo"
   become: true


### PR DESCRIPTION
[Rocky Linux](https://rockylinux.org/) is a community build of RHEL the way CentOS Linux used to be. The GitLab Runner RPM repos hosted at packagecloud.io are not yet configured to install the `el/8` repository on Rocky Linux 8 (which is what they do on CentOS Linux 8). This overrides the OS detection in the repo install script and asks for the configuration for the appropriate repos directly. Other RedHat based distributions are not affected by this change.