### PR TITLE
feat(docker): allow positionning of the host parameter for a docker executor

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,8 @@ gitlab_runner_runners:
     concurrent_specific: '0'
     # The default Docker image to use. Required when executor is `docker`.
     docker_image: ''
+    # The Docker host to use. Required when executor is `docker`.
+    # docker_host: ''
     # The tags assigned to the runner.
     tags: []
     # Indicates whether this runner can pick jobs without tags.

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -175,6 +175,19 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
+- name: Set runner docker host option
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*host ='
+    line: '    host = {{ gitlab_runner.docker_host| default("") | to_json }}'
+    state: "{{ 'present' if gitlab_runner.docker_host is defined else 'absent' }}"
+    insertafter: '^\s*\[runners\.docker\]'
+    backrefs: no
+  check_mode: no
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
+
 - name: Set docker privileged option
   lineinfile:
     dest: "{{ temp_runner_config.path }}"


### PR DESCRIPTION
The parameter allows to specify a remote docker host instead of the default local socket