### PR TITLE
Minimal support for Arch Linux.

### DIFF
--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -10,6 +10,10 @@
   import_tasks: install-macos.yml
   when: ansible_os_family == 'Darwin'
 
+- name: Install GitLab Runner (Arch)
+  import_tasks: install-arch.yml
+  when: ansible_os_family == 'Archlinux'
+
 - name: (Unix) List configured runners
   command: "{{ gitlab_runner_executable }} list"
   register: configured_runners

--- a/tasks/install-arch.yml
+++ b/tasks/install-arch.yml
@@ -1,0 +1,16 @@
+---
+
+- name: (Arch) Set gitlab_runner_package_name
+  set_fact:
+    gitlab_runner_package: "{{ gitlab_runner_package_name }}"
+    gitlab_runner_package_state: "latest"
+  when: gitlab_runner_package_version is not defined
+
+- name: (Arch) Install GitLab Runner
+  package:
+    name: "{{ gitlab_runner_package }}"
+    state: "{{ gitlab_runner_package_state }}"
+  become: true
+
+- name: Set systemd reload options
+  import_tasks: systemd-reload.yml

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,0 +1,8 @@
+---
+
+gitlab_runner_executable: "/usr/bin/{{ gitlab_runner_package_name }}"
+
+gitlab_runner_runtime_owner: gitlab-runner
+gitlab_runner_runtime_group: gitlab-runner
+gitlab_runner_restart_state: reloaded
+gitlab_runner_timeout_stop_seconds: 720


### PR DESCRIPTION
Tested it with the following config and everything worked as expected:

```yml
---
gitlab_runner_coordinator_url: https://XXX.org
gitlab_runner_registration_token: 'XXX'
gitlab_runner_concurrent: 4
gitlab_runner_listen_address: '0.0.0.0:9252'
gitlab_runner_runners:
  - name: 'arch-box1'
    executor: docker
    docker_image: 'ubuntu:20.04'
    tags:
      - docker
      - arch-box1
    docker_volumes:
      - "/var/run/docker.sock:/var/run/docker.sock"
      - "/cache"
      - "/opt/ccache"
      - "/builds"
    env_vars:
      - CTEST_PARALLEL_LEVEL=16
      - OMP_NUM_THREADS=1
```