### PR TITLE
Making the config-runner-windows idempotent & Removing duplicate runner tag/block

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ Feel free to add your name to the readme if you make a PR. A full list of people
 - Gastrofix for adding Mac Support
 - Matthias Schmieder for adding Windows Support
 - dniwdeus & rosenstrauch for adding AWS autoscale option
-
+- oscillate123 for fixing Windows config.toml idempotency

--- a/tasks/config-runners-windows.yml
+++ b/tasks/config-runners-windows.yml
@@ -40,12 +40,6 @@
     win_lineinfile:
       insertbefore: BOF
       path: "{{ config_toml_temp.path }}"
-      line: "[[runners]]"
-
-  - name: (Windows) Write global config to file
-    win_lineinfile:
-      insertbefore: BOF
-      path: "{{ config_toml_temp.path }}"
       line: "{{ runner_global_config }}"
 
   - name: (Windows) Create temporary file runners-config.toml

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -1,10 +1,14 @@
 ---
-- name: (Windows) Print "[[runners]]" section
+- name: (Windows) Set "[[runners]]" section
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
+    regexp: '\n'
     line: '[[runners]]'
     state: present
-    insertbefore: BOF
+    insertbefore: '^\s*name ='
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner_windows
 
 - name: (Windows) Set concurrent limit option
   win_lineinfile:
@@ -340,6 +344,9 @@
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner_windows
+
+- name: (Windows) Remove empty lines
+  win_shell: (Get-Content {{ temp_runner_config.path }}) | ? {$_.trim() -ne "" } | Set-Content {{ temp_runner_config.path }}
 
 - include: section-config-runner-windows.yml
   loop: "{{ gitlab_runner.extra_configs|list }}"


### PR DESCRIPTION
PR to fix #194 

After playbook run, the config.toml gets an extra `[[runners]]` tag, which registers a empty extra runner.

**Before**

```
[[runners]]
[[runners]]
  name = "bc-gr-08_pt2d"
  limit = 0
  output_limit = 4096
```
 and if you run the playbook again it will add additional blankspaces for each time you run it.
```
[[runners]]
[[runners]]

  name = "name"
  limit = 0
  output_limit = 4096
```

**After**

```
[[runners]]
  name = "name"
  limit = 0
  output_limit = 4096
```