### PR TITLE
Add counters in names of tasks, whose are called from loops

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,9 @@ gitlab_runner_restart_state: restarted
 # default value for log_format
 # gitlab_runner_log_format: runner
 
+# controls diffs for assemle config file
+gitlab_runner_show_config_diff: no
+
 # A list of runners to register and configure
 gitlab_runner_runners:
     # The identifier of the runner.

--- a/tasks/Container.yml
+++ b/tasks/Container.yml
@@ -40,11 +40,11 @@
 
 - name: configured_runners?
   debug:
-    msg: "{{configured_runners.container.Output}}"
+    msg: "{{ configured_runners.container.Output }}"
 
 - name: verified_runners?
   debug:
-    msg: "{{verified_runners.container.Output}}"
+    msg: "{{ verified_runners.container.Output }}"
 
 - name: (Container) Register GitLab Runner
   include_tasks: register-runner-container.yml

--- a/tasks/config-runner-container.yml
+++ b/tasks/config-runner-container.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create temporary file
+- name: "{{ conf_name_prefix }} Create temporary file"
   tempfile:
     state: file
     path: "{{ temp_runner_config_dir.path }}"
@@ -8,7 +8,7 @@
   check_mode: no
   changed_when: false
 
-- name: Isolate runner configuration
+- name: "{{ conf_name_prefix }} Isolate runner configuration"
   copy:
     dest: "{{ temp_runner_config.path }}"
     content: "{{ runner_config }}"
@@ -16,6 +16,8 @@
   changed_when: false
 
 - include_tasks: update-config-runner.yml
+  vars:
+    runn_name_prefix: "{{ conf_name_prefix }} runner[{{ (gitlab_runner_index|int) + 1 }}/{{ gitlab_runner_runners|length }}]:"
   when:
     - ('name = "'+gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)+'"') in runner_config
     - gitlab_runner.state|default('present') == 'present'
@@ -24,7 +26,7 @@
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
 
-- name: Remove runner config
+- name: "{{ conf_name_prefix }} Remove runner config"
   file:
     path: "{{ temp_runner_config.path }}"
     state: absent

--- a/tasks/config-runner-windows.yml
+++ b/tasks/config-runner-windows.yml
@@ -1,5 +1,5 @@
 ---
-- name: (Windows) Create temporary file
+- name: "(Windows) {{ conf_name_prefix }} Create temporary file"
   win_tempfile:
     state: file
     path: "{{ temp_runner_config_dir.path }}"
@@ -8,7 +8,7 @@
   check_mode: no
   changed_when: false
 
-- name: (Windows) Isolate runner configuration
+- name: "(Windows) {{ conf_name_prefix }} Isolate runner configuration"
   win_copy:
     dest: "{{ temp_runner_config.path }}"
     content: "{{ runner_config }}"
@@ -16,6 +16,8 @@
   changed_when: false
 
 - include_tasks: update-config-runner-windows.yml
+  vars:
+    runn_name_prefix: "{{ conf_name_prefix }} runner[{{ (gitlab_runner_index|int) + 1 }}/{{ gitlab_runner_runners|length }}]:"
   when:
     - ('name = "'+gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)+'"') in runner_config
     - gitlab_runner.state|default('present') == 'present'
@@ -24,7 +26,7 @@
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
 
-- name: (Windows) Remove runner config
+- name: "(Windows) {{ conf_name_prefix }} Remove runner config"
   win_file:
     path: "{{ temp_runner_config.path }}"
     state: absent

--- a/tasks/config-runner.yml
+++ b/tasks/config-runner.yml
@@ -1,5 +1,6 @@
 ---
-- name: Create temporary file
+
+- name: "{{ conf_name_prefix }} Create temporary file"
   tempfile:
     state: file
     path: "{{ temp_runner_config_dir.path }}"
@@ -8,7 +9,7 @@
   check_mode: no
   changed_when: false
 
-- name: Isolate runner configuration
+- name: "{{ conf_name_prefix }} Isolate runner configuration"
   copy:
     dest: "{{ temp_runner_config.path }}"
     content: "{{ runner_config }}"
@@ -16,6 +17,8 @@
   changed_when: false
 
 - include_tasks: update-config-runner.yml
+  vars:
+    runn_name_prefix: "{{ conf_name_prefix }} runner[{{ (gitlab_runner_index|int) + 1 }}/{{ gitlab_runner_runners|length }}]:"
   when:
     - ('name = "'+gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)+'"') in runner_config
     - gitlab_runner.state|default('present') == 'present'
@@ -24,7 +27,7 @@
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
 
-- name: Remove runner config
+- name: "{{ conf_name_prefix }} Remove runner config"
   file:
     path: "{{ temp_runner_config.path }}"
     state: absent

--- a/tasks/config-runners-container.yml
+++ b/tasks/config-runners-container.yml
@@ -17,6 +17,8 @@
   changed_when: false
 
 - name: Write config section for each runner
+  vars:
+    conf_name_prefix: "conf[{{ (runner_config_index|int) + 1 }}/{{ runner_configs|length }}]:"
   include_tasks: config-runner-container.yml
   loop: "{{ runner_configs }}"
   loop_control:

--- a/tasks/config-runners-container.yml
+++ b/tasks/config-runners-container.yml
@@ -33,6 +33,6 @@
     backup: yes
     validate: |
       docker run -i --rm -v %s:/gitlab-runner.conf
-      {{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }} 
+      {{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}
       verify -c /gitlab-runner.conf
     mode: 0600

--- a/tasks/config-runners-windows.yml
+++ b/tasks/config-runners-windows.yml
@@ -21,6 +21,8 @@
   changed_when: false
 
 - name: (Windows) Write config section for each runner
+  vars:
+    conf_name_prefix: "conf[{{ (runner_config_index|int) + 1 }}/{{ runner_configs|length }}]:"
   include_tasks: config-runner-windows.yml
   loop: "{{ runner_configs }}"
   loop_control:

--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -18,6 +18,8 @@
   changed_when: false
 
 - name: Write config section for each runner
+  vars:
+    conf_name_prefix: "conf[{{ (runner_config_index|int) + 1 }}/{{ runner_configs|length }}]:"
   include_tasks: config-runner.yml
   loop: "{{ runner_configs }}"
   loop_control:
@@ -33,3 +35,4 @@
     validate: "{{ gitlab_runner_executable }} verify -c %s"
     mode: 0600
   become: "{{ gitlab_runner_system_mode }}"
+  diff: "{{ gitlab_runner_show_config_diff|bool }}"

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -39,7 +39,7 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
-- name: Add log_format to config 
+- name: Add log_format to config
   lineinfile:
     dest: "{{ gitlab_runner_config_file }}"
     regexp: '^log_format ='

--- a/tasks/install-windows.yml
+++ b/tasks/install-windows.yml
@@ -38,9 +38,9 @@
       args:
         chdir: "{{ gitlab_runner_config_file_location }}"
       when: (gitlab_runner_windows_service_user | length == 0) or (gitlab_runner_windows_service_password | length == 0)
-    
+
     - name: (Windows) Install GitLab Runner
-      win_command: "{{ gitlab_runner_executable }} install --user \"{{ gitlab_runner_windows_service_user }}\" --password \"{{ gitlab_runner_windows_service_password }}\""
+      win_command: "{{ gitlab_runner_executable }} install --user \"{{ gitlab_runner_windows_service_user }}\" --password \"{{ gitlab_runner_windows_service_password }}\"" # noqa 204
       args:
         chdir: "{{ gitlab_runner_config_file_location }}"
       when:

--- a/tasks/line-config-runner-windows.yml
+++ b/tasks/line-config-runner-windows.yml
@@ -1,11 +1,11 @@
 ---
-- name: (Windows) Ensure section exists
+- name: "(Windows) {{ line_name_prefix }} Ensure section exists"
   win_lineinfile:
     path: "{{ temp_runner_config.path }}"
     regexp: '^(\s*)\[{{ section|regex_escape }}\]$'
     line: '{{ "  " * (section.split(".")|length -1) }}[{{ section }}]'
 
-- name: (Windows) Modify existing line
+- name: "(Windows) {{ line_name_prefix }} Modify existing line"
   win_lineinfile:
     path: "{{ temp_runner_config.path }}"
     insertafter: '\s+\[{{ section | regex_escape }}\]'

--- a/tasks/line-config-runner.yml
+++ b/tasks/line-config-runner.yml
@@ -1,11 +1,11 @@
 ---
-- name: Ensure section exists
+- name: "{{ line_name_prefix }} Ensure section exists"
   lineinfile:
     path: "{{ temp_runner_config.path }}"
     regexp: '^(\s*)\[{{ section|regex_escape }}\]$'
     line: '{{ "  " * (section.split(".")|length -1) }}[{{ section }}]'
 
-- name: Modify existing line
+- name: "{{ line_name_prefix }} Modify existing line"
   lineinfile:
     path: "{{ temp_runner_config.path }}"
     insertafter: '\s+\[{{ section | regex_escape }}\]'

--- a/tasks/section-config-runner-windows.yml
+++ b/tasks/section-config-runner-windows.yml
@@ -1,5 +1,8 @@
 ---
 - include: line-config-runner-windows.yml
+  vars:
+    line_name_prefix: "{{ sect_name_prefix }} line:[{{ (line_index|int) + 1 }}/{{ gitlab_runner.extra_configs[section]|list|length }}]: "
   loop: "{{ gitlab_runner.extra_configs[section] | list }}"
   loop_control:
     loop_var: line
+    index_var: line_index

--- a/tasks/section-config-runner.yml
+++ b/tasks/section-config-runner.yml
@@ -1,5 +1,8 @@
 ---
 - include: line-config-runner.yml
+  vars:
+    line_name_prefix: "{{ sect_name_prefix }} line:[{{ (line_index|int) + 1 }}/{{ gitlab_runner.extra_configs[section]|list|length }}]: "
   loop: "{{ gitlab_runner.extra_configs[section] | list }}"
   loop_control:
     loop_var: line
+    index_var: line_index

--- a/tasks/systemd-reload.yml
+++ b/tasks/systemd-reload.yml
@@ -30,7 +30,7 @@
   when: gitlab_runner_timeout_stop_seconds > 0
   register: gitlab_runner_kill_timeout
 
-- name: Force systemd to reread configs
+- name: Force systemd to reread configs # noqa 503
   become: yes
   systemd:
     daemon_reload: yes

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -1,5 +1,5 @@
 ---
-- name: (Windows) Set "[[runners]]" section
+- name: "(Windows) {{ runn_name_prefix }} Set \"[[runners]]\" section"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '\n'
@@ -10,7 +10,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set concurrent limit option
+- name: "(Windows) {{ runn_name_prefix }} Set concurrent limit option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*limit =.*'
@@ -21,7 +21,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set coordinator URL
+- name: "(Windows) {{ runn_name_prefix }} Set coordinator URL"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*url =.*'
@@ -32,7 +32,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set clone URL
+- name: "(Windows) {{ runn_name_prefix }} Set clone URL"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*clone_url ='
@@ -44,7 +44,7 @@
   notify: restart_gitlab_runner
   when: gitlab_runner.clone_url is defined
 
-- name: (Windows) Set environment option
+- name: "(Windows) {{ runn_name_prefix }} Set environment option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*environment =.*'
@@ -55,7 +55,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set pre_clone_script
+- name: "(Windows) {{ runn_name_prefix }} Set pre_clone_script"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*pre_clone_script ='
@@ -67,7 +67,7 @@
   notify: restart_gitlab_runner
   when: gitlab_runner.pre_clone_script is defined
 
-- name: (Windows) Set pre_build_script
+- name: "(Windows) {{ runn_name_prefix }} Set pre_build_script"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*pre_build_script ='
@@ -79,7 +79,7 @@
   notify: restart_gitlab_runner
   when: gitlab_runner.pre_build_script is defined
 
-- name: (Windows) Set post_build_script
+- name: "(Windows) {{ runn_name_prefix }} Set post_build_script"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*post_build_script ='
@@ -91,7 +91,7 @@
   notify: restart_gitlab_runner
   when: gitlab_runner.post_build_script is defined
 
-- name: (Windows) Set runner executor option
+- name: "(Windows) {{ runn_name_prefix }} Set runner executor option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*executor =.*'
@@ -102,7 +102,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set runner shell option
+- name: "(Windows) {{ runn_name_prefix }} Set runner shell option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*shell =.*'
@@ -113,7 +113,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set output_limit option
+- name: "(Windows) {{ runn_name_prefix }} Set output_limit option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*output_limit =.*'
@@ -124,7 +124,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set runner docker image option
+- name: "(Windows) {{ runn_name_prefix }} Set runner docker image option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*image =.*'
@@ -135,7 +135,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set docker privileged option
+- name: "(Windows) {{ runn_name_prefix }} Set docker privileged option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*privileged =.*'
@@ -146,7 +146,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set docker volumes option
+- name: "(Windows) {{ runn_name_prefix }} Set docker volumes option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*volumes =.*'
@@ -157,7 +157,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set docker devices option
+- name: "(Windows) {{ runn_name_prefix }} Set docker devices option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*devices =.*'
@@ -168,7 +168,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache type option
+- name: "(Windows) {{ runn_name_prefix }} Set cache type option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Type =.*'
@@ -179,7 +179,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache path option
+- name: "(Windows) {{ runn_name_prefix }} Set cache path option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Path =.*'
@@ -190,7 +190,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache s3 server addresss
+- name: "(Windows) {{ runn_name_prefix }} Set cache s3 server address"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*ServerAddress =.*'
@@ -201,7 +201,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache s3 access key
+- name: "(Windows) {{ runn_name_prefix }} Set cache s3 access key"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*AccessKey =.*'
@@ -212,7 +212,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache s3 secret key
+- name: "(Windows) {{ runn_name_prefix }} Set cache s3 secret key"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*SecretKey =.*'
@@ -224,7 +224,7 @@
   notify: restart_gitlab_runner_windows
 
 
-- name: (Windows) Set cache shared option
+- name: "(Windows) {{ runn_name_prefix }} Set cache shared option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Shared =.*'
@@ -235,7 +235,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache s3 bucket name option
+- name: "(Windows) {{ runn_name_prefix }} Set cache s3 bucket name option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*BucketName =.*'
@@ -246,7 +246,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache s3 bucket location option
+- name: "(Windows) {{ runn_name_prefix }} Set cache s3 bucket location option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*BucketLocation =.*'
@@ -257,7 +257,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache s3 insecure option
+- name: "(Windows) {{ runn_name_prefix }} Set cache s3 insecure option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Insecure =.*'
@@ -268,7 +268,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set ssh user option
+- name: "(Windows) {{ runn_name_prefix }} Set ssh user option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*user =.*'
@@ -279,7 +279,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set ssh host option
+- name: "(Windows) {{ runn_name_prefix }} Set ssh host option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*host =.*'
@@ -290,7 +290,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set ssh port option
+- name: "(Windows) {{ runn_name_prefix }} Set ssh port option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*port =.*'
@@ -301,7 +301,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set ssh password option
+- name: "(Windows) {{ runn_name_prefix }} Set ssh password option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*password =.*'
@@ -312,7 +312,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set ssh identity file option
+- name: "(Windows) {{ runn_name_prefix }} Set ssh identity file option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*identity_file =.*'
@@ -323,7 +323,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set builds dir file option
+- name: "(Windows) {{ runn_name_prefix }} Set builds dir file option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*builds_dir =.*'
@@ -334,7 +334,7 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: (Windows) Set cache dir file option
+- name: "(Windows) {{ runn_name_prefix }} Set cache dir file option"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*cache_dir =.*'
@@ -349,9 +349,12 @@
   win_shell: (Get-Content {{ temp_runner_config.path }}) | ? {$_.trim() -ne "" } | Set-Content {{ temp_runner_config.path }}
 
 - include: section-config-runner-windows.yml
+  vars:
+    sect_name_prefix: "{{ runn_name_prefix }} section[{{ (section_index|int) + 1 }}/{{ gitlab_runner.extra_configs|list|length }}]:"
   loop: "{{ gitlab_runner.extra_configs|list }}"
   loop_control:
     loop_var: section
+    index_var: section_index
   when:
     - gitlab_runner.extra_configs is defined
     - gitlab_runner.extra_configs|list|length > 0

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -226,7 +226,7 @@
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
-  
+
 - name:  "{{ runn_name_prefix }} Set docker disable_cache option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set concurrent limit option
+- name:  "{{ runn_name_prefix }} Set concurrent limit option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*limit ='
@@ -12,7 +12,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set coordinator URL
+- name:  "{{ runn_name_prefix }} Set coordinator URL"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*url ='
@@ -25,7 +25,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set clone URL
+- name:  "{{ runn_name_prefix }} Set clone URL"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*clone_url ='
@@ -39,7 +39,7 @@
   - restart_gitlab_runner_macos
   when: gitlab_runner.clone_url is defined
 
-- name: Set environment option
+- name:  "{{ runn_name_prefix }} Set environment option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*environment ='
@@ -52,7 +52,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set pre_clone_script
+- name:  "{{ runn_name_prefix }} Set pre_clone_script"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*pre_clone_script ='
@@ -66,7 +66,7 @@
   - restart_gitlab_runner_macos
   when: gitlab_runner.pre_clone_script is defined
 
-- name: Set pre_build_script
+- name:  "{{ runn_name_prefix }} Set pre_build_script"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*pre_build_script ='
@@ -80,7 +80,7 @@
   - restart_gitlab_runner_macos
   when: gitlab_runner.pre_build_script is defined
 
-- name: Set tls_ca_file
+- name: "{{ runn_name_prefix }} Set tls_ca_file"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*tls-ca-file ='
@@ -94,7 +94,7 @@
   - restart_gitlab_runner_macos
   when: gitlab_runner.tls_ca_file is defined
 
-- name: Set post_build_script
+- name:  "{{ runn_name_prefix }} Set post_build_script"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*post_build_script ='
@@ -108,7 +108,7 @@
   - restart_gitlab_runner_macos
   when: gitlab_runner.post_build_script is defined
 
-- name: Set runner executor option
+- name:  "{{ runn_name_prefix }} Set runner executor option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*executor ='
@@ -121,7 +121,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set runner shell option
+- name:  "{{ runn_name_prefix }} Set runner shell option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*shell ='
@@ -134,7 +134,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set runner executor section
+- name:  "{{ runn_name_prefix }} Set runner executor section"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.{{ gitlab_runner.executor|default("shell") }}\]'
@@ -147,7 +147,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set output_limit option
+- name:  "{{ runn_name_prefix }} Set output_limit option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*output_limit ='
@@ -162,7 +162,7 @@
 
 
 #### [runners.docker] section ####
-- name: Set runner docker image option
+- name:  "{{ runn_name_prefix }} Set runner docker image option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*image ='
@@ -175,7 +175,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set docker privileged option
+- name:  "{{ runn_name_prefix }} Set docker privileged option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*privileged ='
@@ -188,7 +188,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set docker wait_for_services_timeout option
+- name:  "{{ runn_name_prefix }} Set docker wait_for_services_timeout option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*wait_for_services_timeout ='
@@ -201,7 +201,7 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
-- name: Set docker tlsverify option
+- name:  "{{ runn_name_prefix }} Set docker tlsverify option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*tls_verify ='
@@ -214,7 +214,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set docker shm_size option
+- name: "{{ runn_name_prefix }} Set docker shm_size option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*shm_size ='
@@ -226,8 +226,8 @@
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
-
-- name: Set docker disable_cache option
+  
+- name:  "{{ runn_name_prefix }} Set docker disable_cache option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*disable_cache ='
@@ -240,7 +240,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set docker DNS option
+- name:  "{{ runn_name_prefix }} Set docker DNS option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*dns ='
@@ -253,7 +253,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set docker pull_policy option
+- name:  "{{ runn_name_prefix }} Set docker pull_policy option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*pull_policy ='
@@ -266,7 +266,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set docker volumes option
+- name:  "{{ runn_name_prefix }} Set docker volumes option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*volumes ='
@@ -279,7 +279,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set docker devices option
+- name:  "{{ runn_name_prefix }} Set docker devices option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*devices ='
@@ -292,7 +292,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set runner docker network option
+- name:  "{{ runn_name_prefix }} Set runner docker network option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*network_mode ='
@@ -306,7 +306,7 @@
   - restart_gitlab_runner_macos
 
 #### [runners.custom_build_dir] section #####
-- name: Set custom_build_dir section
+- name:  "{{ runn_name_prefix }} Set custom_build_dir section"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.custom_build_dir\]'
@@ -319,7 +319,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set docker custom_build_dir-enabled option
+- name:  "{{ runn_name_prefix }} Set docker custom_build_dir-enabled option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*enabled ='
@@ -333,12 +333,12 @@
   - restart_gitlab_runner_macos
 
 #### [runners.cache] section ####
-- name: Set cache section
+- name:  "{{ runn_name_prefix }} Set cache section"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.cache\]'
     line: '  [runners.cache]'
-    state: "{{ 'present' if gitlab_runner.cache_type is defined else 'absent' }}"
+    state: present
     insertafter: EOF
     backrefs: no
   check_mode: no
@@ -346,7 +346,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache s3 section
+- name:  "{{ runn_name_prefix }} Set cache s3 section"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.cache\.s3\]'
@@ -359,7 +359,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache gcs section
+- name:  "{{ runn_name_prefix }} Set cache gcs section"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.cache\.gcs\]'
@@ -372,7 +372,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache azure section
+- name:  "{{ runn_name_prefix }} Set cache azure section"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.cache\.azure\]'
@@ -385,7 +385,7 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
-- name: Set cache type option
+- name:  "{{ runn_name_prefix }} Set cache type option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Type ='
@@ -398,7 +398,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache path option
+- name:  "{{ runn_name_prefix }} Set cache path option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Path ='
@@ -411,7 +411,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache shared option
+- name:  "{{ runn_name_prefix }} Set cache shared option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Shared ='
@@ -426,7 +426,7 @@
 
 
 #### [runners.cache.s3] section ####
-- name: Set cache s3 server addresss
+- name:  "{{ runn_name_prefix }} Set cache s3 server addresss"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*ServerAddress ='
@@ -439,7 +439,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache s3 access key
+- name:  "{{ runn_name_prefix }} Set cache s3 access key"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*AccessKey ='
@@ -452,7 +452,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache s3 secret key
+- name:  "{{ runn_name_prefix }} Set cache s3 secret key"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*SecretKey ='
@@ -465,7 +465,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache s3 bucket name option
+- name:  "{{ runn_name_prefix }} Set cache s3 bucket name option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*BucketName ='
@@ -479,7 +479,7 @@
   - restart_gitlab_runner_macos
   when: gitlab_runner.cache_type is defined and gitlab_runner.cache_type == 's3'
 
-- name: Set cache s3 bucket location option
+- name:  "{{ runn_name_prefix }} Set cache s3 bucket location option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*BucketLocation ='
@@ -492,7 +492,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache s3 insecure option
+- name:  "{{ runn_name_prefix }} Set cache s3 insecure option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*Insecure ='
@@ -507,7 +507,7 @@
 
 
 #### [runners.cache.gcs] section ####
-- name: Set cache gcs bucket name
+- name:  "{{ runn_name_prefix }} Set cache gcs bucket name"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*BucketName ='
@@ -521,7 +521,7 @@
   - restart_gitlab_runner_macos
   when: gitlab_runner.cache_type is defined and gitlab_runner.cache_type == 'gcs'
 
-- name: Set cache gcs credentials file
+- name:  "{{ runn_name_prefix }} Set cache gcs credentials file"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*CredentialsFile ='
@@ -534,7 +534,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache gcs access id
+- name:  "{{ runn_name_prefix }} Set cache gcs access id"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*AccessID ='
@@ -547,7 +547,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache gcs private key
+- name:  "{{ runn_name_prefix }} Set cache gcs private key"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*PrivateKey ='
@@ -561,7 +561,7 @@
   - restart_gitlab_runner_macos
 
 #### [runners.cache.azure] section ####
-- name: Set cache azure account name
+- name:  "{{ runn_name_prefix }} Set cache azure account name"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*AccountName ='
@@ -574,7 +574,7 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
-- name: Set cache azure account key
+- name:  "{{ runn_name_prefix }} Set cache azure account key"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*AccountKey ='
@@ -587,7 +587,7 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
-- name: Set cache azure container name
+- name:  "{{ runn_name_prefix }} Set cache azure container name"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*ContainerName ='
@@ -600,7 +600,7 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
-- name: Set cache azure storage domain
+- name:  "{{ runn_name_prefix }} Set cache azure storage domain"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*StorageDomain ='
@@ -614,7 +614,7 @@
     - restart_gitlab_runner_macos
 
 #### [runners.ssh] section #####
-- name: Set ssh user option
+- name:  "{{ runn_name_prefix }} Set ssh user option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*user ='
@@ -627,7 +627,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set ssh host option
+- name:  "{{ runn_name_prefix }} Set ssh host option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*host ='
@@ -640,7 +640,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set ssh port option
+- name:  "{{ runn_name_prefix }} Set ssh port option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*port ='
@@ -653,7 +653,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set ssh password option
+- name:  "{{ runn_name_prefix }} Set ssh password option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*password ='
@@ -666,7 +666,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set ssh identity file option
+- name:  "{{ runn_name_prefix }} Set ssh identity file option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*identity_file ='
@@ -680,7 +680,7 @@
   - restart_gitlab_runner_macos
 
 #### [runners.virtualbox] section #####
-- name: Set virtualbox base name option
+- name:  "{{ runn_name_prefix }} Set virtualbox base name option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*base_name ='
@@ -694,7 +694,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set virtualbox base snapshot option
+- name:  "{{ runn_name_prefix }} Set virtualbox base snapshot option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*base_snapshot ='
@@ -708,7 +708,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set virtualbox base folder option
+- name:  "{{ runn_name_prefix }} Set virtualbox base folder option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*base_folder ='
@@ -722,7 +722,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set virtualbox disable snapshots option
+- name:  "{{ runn_name_prefix }} Set virtualbox disable snapshots option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*disable_snapshots ='
@@ -736,7 +736,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set builds dir file option
+- name:  "{{ runn_name_prefix }} Set builds dir file option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*builds_dir ='
@@ -749,7 +749,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Set cache dir file option
+- name:  "{{ runn_name_prefix }} Set cache dir file option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*cache_dir ='
@@ -762,7 +762,7 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name: Ensure directory permissions
+- name:  "{{ runn_name_prefix }} Ensure directory permissions"
   file:
     dest: "{{ item }}"
     state: directory
@@ -777,7 +777,7 @@
     - "{{ gitlab_runner.cache_dir | default(\"\") }}"
   when: item|length
 
-- name: Ensure directory access test
+- name:  "{{ runn_name_prefix }} Ensure directory access test"
   command: "/usr/bin/test -r {{ item }}"
   loop:
     - "{{ gitlab_runner.builds_dir | default(\"\") }}"
@@ -789,7 +789,7 @@
   register: ensure_directory_access
   ignore_errors: true
 
-- name: Ensure directory access fail on error
+- name:  "{{ runn_name_prefix }} Ensure directory access fail on error"
   fail:
     msg: "Error: user gitlab-runner failed to test access to {{ item.item }}. Check parent folder(s) permissions"
   loop: "{{ ensure_directory_access.results }}"
@@ -797,9 +797,12 @@
     - item.rc is defined and item.rc != 0
 
 - include: section-config-runner.yml
+  vars:
+    sect_name_prefix: "{{ runn_name_prefix }} section[{{ (section_index|int) + 1 }}/{{ gitlab_runner.extra_configs|list|length }}]:"
   loop: "{{ gitlab_runner.extra_configs|list }}"
   loop_control:
     loop_var: section
+    index_var: section_index
   when:
     - gitlab_runner.extra_configs is defined
     - gitlab_runner.extra_configs|list|length > 0


### PR DESCRIPTION
- When you have a large config file with many options, running this role looks like loop. I've added progress indicators in names of tasks. It looks like:
`TASK [ansible-gitlab-runner : conf[2/5]: runner[1/4]: section[1/2]: line:[2/6]: Modify existing line]`
- Also add option gitlab_runner_show_config_diff to show diff, when new config replaces old one. But it doesn't work for me, probably because of old version of assemble module.
- In the end I have fixed linter warnings and errors (but add skipping for two of them)