### PR TITLE
Include: directive is being deprecated, change to include_tasks:

### DIFF
--- a/tasks/section-config-runner-windows.yml
+++ b/tasks/section-config-runner-windows.yml
@@ -1,5 +1,5 @@
 ---
-- include: line-config-runner-windows.yml
+- include_tasks: line-config-runner-windows.yml
   vars:
     line_name_prefix: "{{ sect_name_prefix }} line:[{{ (line_index|int) + 1 }}/{{ gitlab_runner.extra_configs[section]|list|length }}]: "
   loop: "{{ gitlab_runner.extra_configs[section] | list }}"

--- a/tasks/section-config-runner.yml
+++ b/tasks/section-config-runner.yml
@@ -1,5 +1,5 @@
 ---
-- include: line-config-runner.yml
+- include_tasks: line-config-runner.yml
   vars:
     line_name_prefix: "{{ sect_name_prefix }} line:[{{ (line_index|int) + 1 }}/{{ gitlab_runner.extra_configs[section]|list|length }}]: "
   loop: "{{ gitlab_runner.extra_configs[section] | list }}"

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -348,7 +348,7 @@
 - name: (Windows) Remove empty lines
   win_shell: (Get-Content {{ temp_runner_config.path }}) | ? {$_.trim() -ne "" } | Set-Content {{ temp_runner_config.path }}
 
-- include: section-config-runner-windows.yml
+- include_tasks: section-config-runner-windows.yml
   vars:
     sect_name_prefix: "{{ runn_name_prefix }} section[{{ (section_index|int) + 1 }}/{{ gitlab_runner.extra_configs|list|length }}]:"
   loop: "{{ gitlab_runner.extra_configs|list }}"

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -796,7 +796,7 @@
   when:
     - item.rc is defined and item.rc != 0
 
-- include: section-config-runner.yml
+- include_tasks: section-config-runner.yml
   vars:
     sect_name_prefix: "{{ runn_name_prefix }} section[{{ (section_index|int) + 1 }}/{{ gitlab_runner.extra_configs|list|length }}]:"
   loop: "{{ gitlab_runner.extra_configs|list }}"


### PR DESCRIPTION
```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

Quick PR to quiet down ansible.