### PR TITLE
Fix permissions of gitlab-runner config file dir

### DIFF
--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ gitlab_runner_config_file_location }}"
     state: directory
-    mode: '0755'
+    mode: '0700'
   become: "{{ gitlab_runner_system_mode }}"
 
 - name: Ensure config.toml exists

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -11,7 +11,7 @@
       file:
         path: "{{ gitlab_runner_config_file_location }}"
         state: directory
-        mode: '0755'
+        mode: '0700'
       become: "{{ gitlab_runner_system_mode }}"
 
     - name: Ensure config.toml exists


### PR DESCRIPTION
The permissions of /etc/gitlab-runner are set to 700 by the
gitlab-runner [post-install script][1]. Use these permissions for the
directory in the Ansible role as well.

Fixes #216.

[1]: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/b57e6fbd6311ef8eec01dd03e171ea3a61b4ef4c/packaging/root/usr/share/gitlab-runner/post-install#L41