### PR TITLE
update minimum ansible version requirement

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Erik-jan Riemers
   description: GitLab Runner
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.7
   platforms:
   - name: EL
     versions:


### PR DESCRIPTION
The readme stats that ansible version 2.7 or higher is required. However, this file still said it was version 2.0