### PR TITLE
Add docker mount variable for fix #226

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ gitlab_runner_container_install: false
 gitlab_runner_container_image: gitlab/gitlab-runner
 gitlab_runner_container_tag: latest
 gitlab_runner_container_name: gitlab-runner
+gitlab_runner_container_mount_path: ''
 gitlab_runner_container_restart_policy: unless-stopped
 # you can define a network which the container connects to
 # this option uses network_mode, thus 'default' will use the first network found in docker network list


### PR DESCRIPTION
This commit adds a role variable available to use to specify docker mount path with {{ gitlab_runner_container_mount_path }}. Extends fix #226