### PR TITLE
Fix gitlab_runner_download_url for MacOS arm64 architecture

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -179,7 +179,7 @@
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*helper_image ='
-    line: '    helper_image = {{ gitlab_runner.docker_helper_image|default('') | to_json }}'
+    line: "    helper_image = {{ gitlab_runner.docker_helper_image|default('') | to_json }}"
     state: "{{ 'present' if gitlab_runner.docker_helper_image is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,5 +1,7 @@
 ---
 
-gitlab_runner_download_url: 'https://gitlab-runner-downloads.s3.amazonaws.com/{{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-darwin-amd64'
+gitlab_runner_arch: "{{ (ansible_machine == 'arm64') | ternary('arm64', 'amd64') }}"
+
+gitlab_runner_download_url: 'https://gitlab-runner-downloads.s3.amazonaws.com/{{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-darwin-{{ gitlab_runner_arch }}'
 
 gitlab_runner_executable: "{{ (ansible_machine == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}/bin/{{ gitlab_runner_package_name }}"


### PR DESCRIPTION
Fix gitlab_runner_download_url for MacOS arm64 architecture and small fix in logic.