### PR TITLE
Create gitlab-runner log directory on MacOS arm64

### DIFF
--- a/tasks/install-macos.yml
+++ b/tasks/install-macos.yml
@@ -20,6 +20,14 @@
     set_fact:
       gitlab_runner_existing_version: "{{ existing_version_shell.stdout if existing_version_shell.rc == 0 else '0' }}"
 
+- name: (MacOS) Precreate gitlab-runner log directory
+  become: yes
+  file:
+    path: /usr/local/var/log
+    state: directory
+    owner: "{{ ansible_user_id | string }}"
+  when: gitlab_runner_arch == 'arm64'
+
 - name: (MacOS) INSTALL GitLab Runner for macOS
   block:
     - name: (MacOS) Download GitLab Runner


### PR DESCRIPTION
When the folder '/usr/local/var/log' doesn't exist gitlab-runner fails to start on M1 architecture.
On Intel it works fine.

Related issue:
https://gitlab.com/gitlab-org/gitlab-runner/-/issues/28136