### PR TITLE
fix: list runners on Mac

### DIFF
--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -19,7 +19,7 @@
   register: configured_runners
   changed_when: False
   check_mode: no
-  become: yes
+  become: "{{ gitlab_runner_system_mode }}"
 
 - name: (Unix) Check runner is registered
   command: "{{ gitlab_runner_executable }} verify"
@@ -27,7 +27,7 @@
   ignore_errors: True
   changed_when: False
   check_mode: no
-  become: yes
+  become: "{{ gitlab_runner_system_mode }}"
 
 - name: (Unix) Register GitLab Runner
   include_tasks: register-runner.yml


### PR DESCRIPTION
To list runners on MacOS one should use the same user mode as everywhere
else.