### PR TITLE
Config property keys not always in quotes with to_json

### DIFF
--- a/tasks/line-config-runner-windows.yml
+++ b/tasks/line-config-runner-windows.yml
@@ -9,6 +9,16 @@
   win_lineinfile:
     path: "{{ temp_runner_config.path }}"
     insertafter: '\s+\[{{ section | regex_escape }}\]'
+    regexp: '^(\s*)({{ line | regex_escape }}|{{ line | regex_escape }}) =.*'
+    line: '{{ "  " * (section.split(".")|length) }}{{ line }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
+  register: modified_config_line
+  when: "not '.' in line"
+
+- name: "(Windows) {{ line_name_prefix }} Modify existing line to_json"
+  win_lineinfile:
+    path: "{{ temp_runner_config.path }}"
+    insertafter: '\s+\[{{ section | regex_escape }}\]'
     regexp: '^(\s*)({{ line | to_json | regex_escape }}|{{ line | regex_escape }}) =.*'
     line: '{{ "  " * (section.split(".")|length) }}{{ line | to_json }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
   register: modified_config_line
+  when: "'.' in line"

--- a/tasks/line-config-runner.yml
+++ b/tasks/line-config-runner.yml
@@ -9,6 +9,16 @@
   lineinfile:
     path: "{{ temp_runner_config.path }}"
     insertafter: '\s+\[{{ section | regex_escape }}\]'
+    regexp: '^(\s*)({{ line | regex_escape }}|{{ line | regex_escape }}) ='
+    line: '{{ "  " * (section.split(".")|length) }}{{ line }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
+  register: modified_config_line
+  when: "not '.' in line"
+
+- name: "{{ line_name_prefix }} Modify existing line to_json"
+  lineinfile:
+    path: "{{ temp_runner_config.path }}"
+    insertafter: '\s+\[{{ section | regex_escape }}\]'
     regexp: '^(\s*)({{ line | to_json | regex_escape }}|{{ line | regex_escape }}) ='
     line: '{{ "  " * (section.split(".")|length) }}{{ line | to_json }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
   register: modified_config_line
+  when: "'.' in line"


### PR DESCRIPTION
the keys for extra-config-options should not always be in quotes. this happens because every line is filtered with to_json.
now quotes (to_json) will only apply if the key contains a dot and is neccessary because of the "runners.docker.sysctls" section.