### PR TITLE
Option to force accept self signed cert from gitlab server.

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -23,6 +23,10 @@
       become: "{{ gitlab_runner_system_mode }}"
   when: (verified_runners.stderr.find("Verifying runner... is removed") != -1)
 
+- name: Accept gitlab server self signed cert as valid CA
+  shell: "openssl s_client -connect {{gitlab_server_ip}}:443 -showcerts </dev/null 2>/dev/null | sed -e '/-----BEGIN/,/-----END/!d' | tee {{tls_ca_file}} >/dev/null"
+  when: force_accept_gitlab_server_self_signed
+
 - name: Construct the runner command without secrets
   # makes the command visible in awx without the secrets and therefore helps with debugging
   set_fact:


### PR DESCRIPTION
gitlab-runner register lacks an option to accept untrusted certificates. In dev environments this can sometimes be hand. This PR works around the issue by downloading the cert of the gitlab server and putting it in the file reference by the var "tls_ca_file" when the var "force_accept_gitlab_server_self_signed" is true.