### PR TITLE
Add default value for force_accept_gitlab_server_self_signed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,9 @@ gitlab_runner_restart_state: restarted
 # default value for log_format
 # gitlab_runner_log_format: runner
 
+# default value for force accept self signed certificates
+force_accept_gitlab_server_self_signed
+
 # controls diffs for assemle config file
 gitlab_runner_show_config_diff: no
 


### PR DESCRIPTION
Without it an error is raised `'force_accept_gitlab_server_self_signed' is undefined`

```json
{
  "msg": "The conditional check 'force_accept_gitlab_server_self_signed' failed. The error was: error while evaluating conditional (force_accept_gitlab_server_self_signed): 'force_accept_gitlab_server_self_signed' is undefined\n\nThe error appears to have been in '/root/.ansible/roles/riemers.gitlab-runner/tasks/register-runner.yml': line 26, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Accept gitlab server self signed cert as valid CA\n  ^ here\n"
}
```