### PR TITLE
Fix: Syntax error "could not find expected ':'"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,7 +68,7 @@ gitlab_runner_restart_state: restarted
 # gitlab_runner_log_format: runner
 
 # default value for force accept self signed certificates
-force_accept_gitlab_server_self_signed
+force_accept_gitlab_server_self_signed: false
 
 # controls diffs for assemle config file
 gitlab_runner_show_config_diff: no


### PR DESCRIPTION
#243 added an option to allow self-signed certificates.
This caused all existing playbooks to fail because they missed a value for `force_accept_gitlab_server_self_signed`.

#244 tried to add a default value for `force_accept_gitlab_server_self_signed`.
Unfortunately, the change introduced invalid YAML:

```
ERROR! We were unable to read either as JSON nor YAML, these are the errors we got from each:
JSON: Expecting value: line 1 column 1 (char 0)
Syntax Error while loading YAML.
  could not find expected ':'
The error appears to be in '/root/.ansible/roles/riemers.gitlab-runner/defaults/main.yml': line 73, column 1, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
# controls diffs for assemle config file
^ here
```

This pull request fixes the syntax error by setting the default value to `false`.