### PR TITLE
Update CA-bundle after (optionally) accepting self signed cert from gitlab server

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -27,6 +27,10 @@
   shell: "openssl s_client -connect {{gitlab_server_ip}}:443 -showcerts </dev/null 2>/dev/null | sed -e '/-----BEGIN/,/-----END/!d' | tee {{tls_ca_file}} >/dev/null"
   when: force_accept_gitlab_server_self_signed
 
+- name: Update CA bundle with self signe cert of the gitlab server
+  import_tasks: update-ca-bundle.yml
+  when: force_accept_gitlab_server_self_signed
+
 - name: Construct the runner command without secrets
   # makes the command visible in awx without the secrets and therefore helps with debugging
   set_fact:

--- a/tasks/update-ca-bundle.yml
+++ b/tasks/update-ca-bundle.yml
@@ -1,0 +1,24 @@
+- name: install ca package on rhel systems
+  yum:
+    name: ca-certificates
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: install ca package on debian systems
+  apt:
+    name: ca-certificates
+    state: present
+    update_cache: yes
+  when: ansible_os_family == "Debian"
+
+- name: enable dynamic ca configuration on rhel6
+  shell: /bin/update-ca-trust enable
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
+
+- name: update trusted ca debian
+  shell: /usr/sbin/update-ca-certificates
+  when: ansible_os_family == "Debian"
+
+- name: update trusted ca redhat
+  shell: /bin/update-ca-trust
+  when: ansible_os_family == "RedHat"


### PR DESCRIPTION
- When parameter `force_accept_gitlab_server_self_signed` is set to true the self signed cert of the gitlab server is stored in the location of `tls_ca_file` parameter (previous change)
- This change will run update of the CA-store too so that when `tls_ca_file` is the location for local certificate approval (for example /usr/local/share/ca-certificates on ubuntu), all https clients that use the "system CA-bundle" will accept the gitlab server certificate
- This is necessary for CI/CD-pipelines to work properly when runner needs to clone code from the gitlab server over https
- Should work on RedHat/CentOS/Ubuntu/Debian . Tested on Ubuntu 22.04