### PR TITLE
Pin the installed version on Debian/Ubuntu and allow downgrades

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -25,6 +25,11 @@
     gitlab_runner_package_state: "latest"
   when: gitlab_runner_package_version is not defined
 
+- name: (Debian) Unhold GitLab Runner version
+  dpkg_selections:
+    name: "{{ gitlab_runner_package_name }}"
+    selection: install
+
 - name: (Debian) Install GitLab Runner
   apt:
     name: "{{ gitlab_runner_package }}"

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: (Debian) Get Gitlab repository installation script
   get_url:
     url: "https://packages.gitlab.com/install/repositories/runner/{{ gitlab_runner_package_name }}/script.deb.sh"
@@ -30,6 +29,7 @@
   apt:
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
+    allow_downgrade: true
   become: true
   environment:
     GITLAB_RUNNER_DISABLE_SKEL: "true"
@@ -39,8 +39,15 @@
   apt:
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
+    allow_downgrade: true
   become: true
   when: ansible_distribution_release not in ["buster", "focal", "jammy"]
+
+- name: (Debian) Hold GitLab Runner version
+  dpkg_selections:
+    name: "{{ gitlab_runner_package_name }}"
+    selection: hold
+  when: gitlab_runner_package_version is defined
 
 - name: (Debian) Remove ~/gitlab-runner/.bash_logout on debian buster and ubuntu focal
   file:


### PR DESCRIPTION
This freezes the installed GitLab Runner version on Debian/Ubuntu hosts when we specify a version from in the role variables. This ensures that running a packages upgrade on the machine does not update the GitLab Runner to a newer version, and keep it at the version installed by the role instead.

This also allows downgrading to a version specified from the role when the one installed on the machine is greater.

The drawback is that the used `allow_downgrade` option from the built-in apt module to achieve this is only available from Ansible version 5 and onwards (Ansible-core 2.12+)

I was tempted to also update the `min_ansible_version` and README to specify this, however since this only impacts Debian/Ubuntu hosts, I was not too sure about bumping the required version only for a single target OS, but maybe a note in the README would be needed.