### PR TITLE
Fix problem with deleted runners

### DIFF
--- a/tasks/Container.yml
+++ b/tasks/Container.yml
@@ -3,6 +3,23 @@
   import_tasks: install-container.yml
   when: gitlab_runner_container_install
 
+- name: (Container) Delete no longer existing runners
+  docker_container:
+    name: "{{ gitlab_runner_container_name }}-check"
+    image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
+    command: verify --delete
+    mounts:
+      - type: bind
+        source: "{{ gitlab_runner_container_mount_path }}"
+        target: /etc/gitlab-runner
+    cleanup: yes
+    interactive: yes
+    tty: yes
+    detach: no
+  register: verified_runners
+  changed_when: '"Updated " in verified_runners.container.Output'
+  check_mode: no
+
 - name: (Container) List configured runners
   docker_container:
     name: "{{ gitlab_runner_container_name }}-list"
@@ -19,32 +36,6 @@
   register: configured_runners
   changed_when: False
   check_mode: no
-
-- name: (Container) Check runner is registered
-  docker_container:
-    name: "{{ gitlab_runner_container_name }}-check"
-    image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
-    command: verify
-    mounts:
-      - type: bind
-        source: "{{ gitlab_runner_container_mount_path }}"
-        target: /etc/gitlab-runner
-    cleanup: yes
-    interactive: yes
-    tty: yes
-    detach: no
-  register: verified_runners
-  ignore_errors: True
-  changed_when: False
-  check_mode: no
-
-- name: configured_runners?
-  debug:
-    msg: "{{ configured_runners.container.Output }}"
-
-- name: verified_runners?
-  debug:
-    msg: "{{ verified_runners.container.Output }}"
 
 - name: (Container) Register GitLab Runner
   include_tasks: register-runner-container.yml

--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -14,17 +14,16 @@
   import_tasks: install-arch.yml
   when: ansible_os_family == 'Archlinux'
 
-- name: (Unix) List configured runners
-  command: "{{ gitlab_runner_executable }} list"
-  register: configured_runners
-  changed_when: False
+- name: (Unix) Delete no longer existing runners
+  command: "{{ gitlab_runner_executable }} verify --delete"
+  register: verified_runners
+  changed_when: '"Updated " in verified_runners.stderr'
   check_mode: no
   become: "{{ gitlab_runner_system_mode }}"
 
-- name: (Unix) Check runner is registered
-  command: "{{ gitlab_runner_executable }} verify"
-  register: verified_runners
-  ignore_errors: True
+- name: (Unix) List configured runners
+  command: "{{ gitlab_runner_executable }} list"
+  register: configured_runners
   changed_when: False
   check_mode: no
   become: "{{ gitlab_runner_system_mode }}"

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -1,20 +1,19 @@
 - name: Install GitLab Runner (Windows)
   import_tasks: install-windows.yml
 
+- name: (Windows) Delete no longer existing runners
+  win_command: "{{ gitlab_runner_executable }} verify --delete"
+  args:
+    chdir: "{{ gitlab_runner_config_file_location }}"
+  register: verified_runners
+  changed_when: '"Updated " in verified_runners.stderr'
+  check_mode: no
+
 - name: (Windows) List configured runners
   win_command: "{{ gitlab_runner_executable }} list"
   args:
     chdir: "{{ gitlab_runner_config_file_location }}"
   register: configured_runners
-  changed_when: False
-  check_mode: no
-
-- name: (Windows) Check runner is registered
-  win_command: "{{ gitlab_runner_executable }} verify"
-  args:
-    chdir: "{{ gitlab_runner_config_file_location }}"
-  register: verified_runners
-  ignore_errors: True
   changed_when: False
   check_mode: no
 

--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -1,18 +1,4 @@
 ---
-- name: Clear Config File
-  block:
-    - name: remove config.toml file
-      file:
-        path: "{{ gitlab_runner_config_file }}"
-        state: absent
-
-    - name: Ensure config.toml exists
-      file:
-        path: "{{ gitlab_runner_config_file }}"
-        state: touch
-        modification_time: preserve
-        access_time: preserve
-  when: (verified_runners.container.Output.find("Verifying runner... is removed") != -1)
 
 - name: Register runner to GitLab
   docker_container:
@@ -123,7 +109,6 @@
     cleanup: yes
     auto_remove: yes
     network_mode: "{{ gitlab_runner_container_network }}"
-  when: (verified_runners.container.Output.find("Verifying runner... is removed") != -1) or
-        ((configured_runners.container.Output.find('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) == -1) and
-        (gitlab_runner.state|default('present') == 'present'))
+  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) not in configured_runners.container.Output and
+        gitlab_runner.state|default('present') == 'present'
   no_log: false

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -1,23 +1,4 @@
 ---
-- name: (Windows) Clear Config File
-  block:
-    - name: (Windows) remove config.toml file
-      win_file:
-        path: "{{ gitlab_runner_config_file }}"
-        state: absent
-
-    - name: (Windows) Create .gitlab-runner dir
-      win_file:
-        path: "{{ gitlab_runner_config_file_location }}"
-        state: directory
-
-    - name: (Windows) Ensure config.toml exists
-      win_file:
-        path: "{{ gitlab_runner_config_file }}"
-        state: touch
-        modification_time: preserve
-        access_time: preserve
-  when: (verified_runners.stderr.find("Verifying runner... is removed") != -1)
 
 - name: (Windows) Register runner to GitLab
   win_shell: >
@@ -119,9 +100,7 @@
     {% if gitlab_runner.extra_registration_option is defined %}
     {{ gitlab_runner.extra_registration_option }}
     {% endif %}
-  when: (verified_runners.stderr.find("Verifying runner... is removed") != -1) or
-        ((configured_runners.stderr.find('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) == -1) and
-        (gitlab_runner.state|default('present') == 'present'))
+  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) not in configured_runners.stderr and
+        gitlab_runner.state|default('present') == 'present'
   args:
     chdir: "{{ gitlab_runner_config_file_location }}"
-  #no_log: true

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -1,27 +1,4 @@
 ---
-- name: Clear Config File
-  block:
-    - name: remove config.toml file
-      file:
-        path: "{{ gitlab_runner_config_file }}"
-        state: absent
-      become: "{{ gitlab_runner_system_mode }}"
-
-    - name: Create .gitlab-runner dir
-      file:
-        path: "{{ gitlab_runner_config_file_location }}"
-        state: directory
-        mode: '0700'
-      become: "{{ gitlab_runner_system_mode }}"
-
-    - name: Ensure config.toml exists
-      file:
-        path: "{{ gitlab_runner_config_file }}"
-        state: touch
-        modification_time: preserve
-        access_time: preserve
-      become: "{{ gitlab_runner_system_mode }}"
-  when: (verified_runners.stderr.find("Verifying runner... is removed") != -1)
 
 - name: Accept gitlab server self signed cert as valid CA
   shell: "openssl s_client -connect {{gitlab_server_ip}}:443 -showcerts </dev/null 2>/dev/null | sed -e '/-----BEGIN/,/-----END/!d' | tee {{tls_ca_file}} >/dev/null"
@@ -163,8 +140,7 @@
     --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
     {% endif %}
     --ssh-password '{{ gitlab_runner.ssh_password|default("") }}'
-  when: (verified_runners.stderr.find("Verifying runner... is removed") != -1) or
-        ((configured_runners.stderr.find('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) == -1) and
-        (gitlab_runner.state|default('present') == 'present'))
+  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) not in configured_runners.stderr and
+        gitlab_runner.state|default('present') == 'present'
   no_log: true
   become: "{{ gitlab_runner_system_mode }}"


### PR DESCRIPTION
Hi,

it seems that there is an issue when we have a simple situation like this

```
Runner1
* ExecutorA - valid
* ExecutorB - deleted (this executor was deleted in the Gitlab UI by removing it in the runner tab)
```

When I let this role run again, the result is very strange and the following will happen:

```
* ExecutorA is not longer available on the runner - in the UI the executor is then marked as offline
* ExecutorB - valid
```

Expected output would be:
```
* ExecutorA - valid
* ExecutorB -valid
```

I narrowed it down to have something todo because the list of runners is queried and when at least one runner is in a bad shape (deleted) then the whole `config.toml` is deleted, but the valid runner is then not again registered.

---

This MR fixes this so that deleted executors don't affect other executors. This is archived by 
* Running `gitlab-runner verify --delete` which removes deleted executors from the config
* Avoid deleting the `config.toml`

