### PR TITLE
Apply updates to runners by untegister and register them again

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ On Linux, use `gitlab_runner_package_version` instead.
 - `gitlab_runner_listen_address` - Enable `/metrics` endpoint for Prometheus scraping.
 - `gitlab_runner_runners` - A list of gitlab runners to register & configure. Defaults to a single shell executor.
 - `gitlab_runner_skip_package_repo_install`- Skip the APT or YUM repository installation (by default, false). You should provide a repository containing the needed packages before running this role.
+- `gitlab_runner_config_update_mode`- Set to `by_config_toml` (default) if this role should apply config changes by updating the `config.toml` itself or set it to `by_registering` if config changes should be applied by unregistering and regeistering the runner in case the config has changed.
 
 See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file listing all possible options which you can be passed to a runner registration command.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,8 @@ gitlab_runner_session_server_session_timeout: 1800
 # Use this if you use a mirror repository
 # gitlab_runner_skip_package_repo_install: true
 
+gitlab_runner_config_update_mode: by_config_toml
+
 # The credentials for the Windows user used to run the gitlab-runner service.
 # Those credentials will be passed to `gitlab-runner.exe install`.
 # https://docs.gitlab.com/runner/install/windows.html

--- a/tasks/Container.yml
+++ b/tasks/Container.yml
@@ -20,26 +20,9 @@
   changed_when: '"Updated " in verified_runners.container.Output'
   check_mode: no
 
-- name: (Container) List configured runners
-  docker_container:
-    name: "{{ gitlab_runner_container_name }}-list"
-    image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
-    command: list
-    mounts:
-      - type: bind
-        source: "{{ gitlab_runner_container_mount_path }}"
-        target: /etc/gitlab-runner
-    cleanup: yes
-    interactive: yes
-    tty: yes
-    detach: no
-  register: configured_runners
-  changed_when: False
-  check_mode: no
-
 - name: (Container) Register GitLab Runner
   include_tasks: register-runner-container.yml
-  when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0  # Ensure value is set
+  when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     index_var: gitlab_runner_index
@@ -49,7 +32,8 @@
   import_tasks: global-setup.yml
 
 - name: (Container) Configure GitLab Runner
-  import_tasks: config-runners-container.yml
+  include_tasks: config-runners-container.yml
+  when: gitlab_runner_config_update_mode == 'by_config_toml'
 
 - name: (Container) Start the container
   docker_container:

--- a/tasks/Unix.yml
+++ b/tasks/Unix.yml
@@ -21,16 +21,9 @@
   check_mode: no
   become: "{{ gitlab_runner_system_mode }}"
 
-- name: (Unix) List configured runners
-  command: "{{ gitlab_runner_executable }} list"
-  register: configured_runners
-  changed_when: False
-  check_mode: no
-  become: "{{ gitlab_runner_system_mode }}"
-
 - name: (Unix) Register GitLab Runner
   include_tasks: register-runner.yml
-  when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0  # Ensure value is set
+  when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     index_var: gitlab_runner_index
@@ -40,4 +33,5 @@
   import_tasks: global-setup.yml
 
 - name: (Unix) Configure GitLab Runner
-  import_tasks: config-runners.yml
+  include_tasks: config-runners.yml
+  when: gitlab_runner_config_update_mode == 'by_config_toml'

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -9,17 +9,9 @@
   changed_when: '"Updated " in verified_runners.stderr'
   check_mode: no
 
-- name: (Windows) List configured runners
-  win_command: "{{ gitlab_runner_executable }} list"
-  args:
-    chdir: "{{ gitlab_runner_config_file_location }}"
-  register: configured_runners
-  changed_when: False
-  check_mode: no
-
 - name: (Windows) Register GitLab Runner
   include_tasks: register-runner-windows.yml
-  when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0  # Ensure value is set
+  when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     index_var: gitlab_runner_index
@@ -29,7 +21,8 @@
   import_tasks: global-setup-windows.yml
 
 - name: (Windows) Configure GitLab Runner
-  import_tasks: config-runners-windows.yml
+  include_tasks: config-runners-windows.yml
+  when: gitlab_runner_config_update_mode == 'by_config_toml'
 
 - name: (Windows) Start GitLab Runner
   win_command: "{{ gitlab_runner_executable }} start"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,13 +11,13 @@
         - 'vars'
 
 - name: Install Gitlab Runner (Container)
-  import_tasks: Container.yml
+  include_tasks: Container.yml
   when: gitlab_runner_container_install
 
 - name: Install GitLab Runner (Unix)
-  import_tasks: Unix.yml
+  include_tasks: Unix.yml
   when: ansible_os_family != 'Windows' and not gitlab_runner_container_install
 
 - name: Install GitLab Runner (Windows)
-  import_tasks: Windows.yml
+  include_tasks: Windows.yml
   when: ansible_os_family == 'Windows' and not gitlab_runner_container_install

--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -1,14 +1,11 @@
 ---
 
-- name: Register runner to GitLab
-  docker_container:
-    name: "{{ gitlab_runner_container_name }}"
-    image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
-    command: |
+- name: Construct the runner command without secrets
+  set_fact:
+    register_runner_cmd: >
       register
       --non-interactive
       --url '{{ gitlab_runner.url | default(gitlab_runner_coordinator_url) }}'
-      --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
       --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
       --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
       {% if gitlab_runner.clone_url|default(false) %}
@@ -64,7 +61,6 @@
       --ssh-user '{{ gitlab_runner.ssh_user|default("") }}'
       --ssh-host '{{ gitlab_runner.ssh_host|default("") }}'
       --ssh-port '{{ gitlab_runner.ssh_port|default("") }}'
-      --ssh-password '{{ gitlab_runner.ssh_password|default("") }}'
       --ssh-identity-file '{{ gitlab_runner.ssh_identity_file|default("") }}'
       {% if gitlab_runner.cache_type is defined %}
       --cache-type '{{ gitlab_runner.cache_type }}'
@@ -79,9 +75,6 @@
       --cache-s3-server-address '{{ gitlab_runner.cache_s3_server_address }}'
       {% if gitlab_runner.cache_s3_access_key is defined %}
       --cache-s3-access-key '{{ gitlab_runner.cache_s3_access_key }}'
-      {% endif %}
-      {% if gitlab_runner.cache_s3_secret_key is defined %}
-      --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
       {% endif %}
       {% endif %}
       {% if gitlab_runner.cache_s3_bucket_name is defined %}
@@ -102,6 +95,90 @@
       {% if gitlab_runner.extra_registration_option is defined %}
       {{ gitlab_runner.extra_registration_option }}
       {% endif %}
+
+- name: Apply updates (if any) by unregister the runner and let it then register later on
+  block:
+    - name: Check if the configuration has changed since the last run
+      ansible.builtin.copy:
+        content: >
+          {{ register_runner_cmd }}
+          --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
+          {% if gitlab_runner.cache_s3_secret_key is defined %}
+          --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key|hash("sha1") }}'
+          {% endif %}
+          {% if gitlab_runner.ssh_password is defined %}
+          --ssh-password '{{ gitlab_runner.ssh_password|hash("sha1") }}'
+          {% endif %}
+        dest: '{{ gitlab_runner_config_file_location }}/last-runner-config-{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
+      register: runner_config_state
+
+    - name: List configured runners
+      docker_container:
+        name: "{{ gitlab_runner_container_name }}-list"
+        image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
+        command: list
+        mounts:
+          - type: bind
+            source: "{{ gitlab_runner_container_mount_path }}"
+            target: /etc/gitlab-runner
+        cleanup: yes
+        interactive: yes
+        tty: yes
+        detach: no
+      register: configured_runners
+      changed_when: False
+      check_mode: no
+
+    - name: Unregister runner when config has changed
+      docker_container:
+        name: "{{ gitlab_runner_container_name }}-list"
+        image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
+        command: unregister --name {{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
+        mounts:
+          - type: bind
+            source: "{{ gitlab_runner_container_mount_path }}"
+            target: /etc/gitlab-runner
+        cleanup: yes
+        interactive: yes
+        tty: yes
+        detach: no
+      register: configured_runners
+      changed_when: False
+      check_mode: no
+      when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string) + ' ') in configured_runners.stderr and
+          runner_config_state.changed
+  when: gitlab_runner_config_update_mode == 'by_registering'
+
+- name: List configured runners
+  docker_container:
+    name: "{{ gitlab_runner_container_name }}-list"
+    image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
+    command: list
+    mounts:
+      - type: bind
+        source: "{{ gitlab_runner_container_mount_path }}"
+        target: /etc/gitlab-runner
+    cleanup: yes
+    interactive: yes
+    tty: yes
+    detach: no
+  register: configured_runners
+  changed_when: False
+  check_mode: no
+
+- name: Register runner to GitLab
+  docker_container:
+    name: "{{ gitlab_runner_container_name }}"
+    image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
+    command: >
+      {{ register_runner_cmd }}
+      --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
+      {% if gitlab_runner.cache_s3_secret_key is defined %}
+      --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
+      {% endif %}
+      {% if gitlab_runner.ssh_password is defined %}
+      --ssh-password '{{ gitlab_runner.ssh_password }}'
+      {% endif %}
     mounts:
     - type: bind
       source: "{{ gitlab_runner_container_mount_path }}"
@@ -109,6 +186,6 @@
     cleanup: yes
     auto_remove: yes
     network_mode: "{{ gitlab_runner_container_network }}"
-  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) not in configured_runners.container.Output and
+  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string) + ' ') not in configured_runners.container.Output and
         gitlab_runner.state|default('present') == 'present'
   no_log: false

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -1,106 +1,149 @@
 ---
 
+- name: Construct the runner command without secrets
+  set_fact:
+    register_runner_cmd: >
+      {{ gitlab_runner_executable }} register
+      --non-interactive
+      --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
+      --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
+      --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
+      {% if gitlab_runner.clone_url|default(false) %}
+      --clone-url "{{ gitlab_runner.clone_url }}"
+      {% endif %}
+      {% if gitlab_runner.run_untagged|default(true) %}
+      --run-untagged
+      {% endif %}
+      {% if gitlab_runner.protected|default(false) %}
+      --access-level="ref_protected"
+      {% endif %}
+      --executor '{{ gitlab_runner.executor|default("shell") }}'
+      {% if gitlab_runner.shell is defined %}
+      --shell '{{ gitlab_runner.shell }}'
+      {% endif %}
+      --limit '{{ gitlab_runner.concurrent_specific|default(0) }}'
+      --output-limit '{{ gitlab_runner.output_limit|default(4096) }}'
+      --locked='{{ gitlab_runner.locked|default(false) }}'
+      {% for env_var in gitlab_runner.env_vars|default([]) %}
+      --env '{{ env_var }}'
+      {% endfor %}
+      {% if gitlab_runner.pre_clone_script|default(false) %}
+      --pre-clone-script "{{ gitlab_runner.pre_clone_script }}"
+      {% endif %}
+      {% if gitlab_runner.pre_build_script|default(false) %}
+      --pre-build-script "{{ gitlab_runner.pre_build_script }}"
+      {% endif %}
+      {% if gitlab_runner.tls_ca_file|default(false) %}
+      --tls-ca-file "{{ gitlab_runner.tls_ca_file }}"
+      {% endif %}
+      {% if gitlab_runner.post_build_script|default(false) %}
+      --post-build-script "{{ gitlab_runner.post_build_script }}"
+      {% endif %}
+      --docker-image '{{ gitlab_runner.docker_image|default("alpine") }}'
+      {% if gitlab_runner.docker_privileged|default(false) %}
+      --docker-privileged
+      {% endif %}
+      {% for volume in gitlab_runner.docker_volumes | default([]) %}
+      --docker-volumes "{{ volume }}"
+      {% endfor %}
+      {% for device in gitlab_runner.docker_devices | default([]) %}
+      --docker-devices "{{ device }}"
+      {% endfor %}
+      {% if gitlab_runner.ssh_user is defined %}
+      --ssh-user '{{ gitlab_runner.ssh_user }}'
+      {% endif %}
+      {% if gitlab_runner.ssh_host is defined %}
+      --ssh-host '{{ gitlab_runner.ssh_host }}'
+      {% endif %}
+      {% if gitlab_runner.ssh_port is defined %}
+      --ssh-port '{{ gitlab_runner.ssh_port }}'
+      {% endif %}
+      {% if gitlab_runner.ssh_identity_file is defined %}
+      --ssh-identity-file '{{ gitlab_runner.ssh_identity_file }}'
+      {% endif %}
+      {% if gitlab_runner.cache_type is defined %}
+      --cache-type '{{ gitlab_runner.cache_type }}'
+      {% endif %}
+      {% if gitlab_runner.cache_shared|default(false) %}
+      --cache-shared
+      {% endif %}
+      {% if gitlab_runner.cache_path is defined %}
+      --cache-path '{{ gitlab_runner.cache_path }}'
+      {% endif %}
+      {% if gitlab_runner.cache_s3_server_address is defined %}
+      --cache-s3-server-address '{{ gitlab_runner.cache_s3_server_address }}'
+      {% endif %}
+      {% if gitlab_runner.cache_s3_access_key is defined %}
+      --cache-s3-access-key '{{ gitlab_runner.cache_s3_access_key }}'
+      {% endif %}
+      {% if gitlab_runner.cache_s3_bucket_name is defined %}
+      --cache-s3-bucket-name '{{ gitlab_runner.cache_s3_bucket_name }}'
+      {% endif %}
+      {% if gitlab_runner.cache_s3_bucket_location is defined %}
+      --cache-s3-bucket-location '{{ gitlab_runner.cache_s3_bucket_location }}'
+      {% endif %}
+      {% if gitlab_runner.builds_dir|default(false) %}
+      --builds-dir '{{ gitlab_runner.builds_dir }}'
+      {% endif %}
+      {% if gitlab_runner.cache_dir|default(false) %}
+      --cache-dir '{{ gitlab_runner.cache_dir }}'
+      {% endif %}
+      {% if gitlab_runner.cache_s3_insecure|default(false) %}
+      --cache-s3-insecure
+      {% endif %}
+      {% if gitlab_runner.extra_registration_option is defined %}
+      {{ gitlab_runner.extra_registration_option }}
+      {% endif %}
+
+- name: Apply updates (if any) by unregister the runner and let it then register later on
+  block:
+    - name: Check if the configuration has changed since the last run
+      ansible.builtin.copy:
+        content: >
+          {{ register_runner_cmd }}
+          --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
+          {% if gitlab_runner.cache_s3_secret_key is defined %}
+          --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key|hash("sha1") }}'
+          {% endif %}
+          {% if gitlab_runner.ssh_password is defined %}
+          --ssh-password '{{ gitlab_runner.ssh_password|hash("sha1") }}'
+          {% endif %}
+        dest: '{{ gitlab_runner_config_file_location }}/last-runner-config-{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
+      register: runner_config_state
+
+    - name: (Windows) List configured runners
+      win_command: "{{ gitlab_runner_executable }} list"
+      args:
+        chdir: "{{ gitlab_runner_config_file_location }}"
+      register: configured_runners
+      changed_when: False
+      check_mode: no
+
+    - name: (Windows) Unregister runner when config has changed
+      win_command: '{{ gitlab_runner_executable }} unregister --name {{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
+      when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string) + ' ') in configured_runners.stderr and
+            runner_config_state.changed
+  when: gitlab_runner_config_update_mode == 'by_registering'
+
+- name: (Windows) List configured runners again
+  win_command: "{{ gitlab_runner_executable }} list"
+  args:
+    chdir: "{{ gitlab_runner_config_file_location }}"
+  register: configured_runners
+  changed_when: False
+  check_mode: no
+
 - name: (Windows) Register runner to GitLab
   win_shell: >
-    {{ gitlab_runner_executable }} register
-    --non-interactive
-    --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
+    {{ register_runner_cmd }}
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
-    --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
-    --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
-    {% if gitlab_runner.clone_url|default(false) %}
-    --clone-url "{{ gitlab_runner.clone_url }}"
-    {% endif %}
-    {% if gitlab_runner.run_untagged|default(true) %}
-    --run-untagged
-    {% endif %}
-    {% if gitlab_runner.protected|default(false) %}
-    --access-level="ref_protected"
-    {% endif %}
-    --executor '{{ gitlab_runner.executor|default("shell") }}'
-    {% if gitlab_runner.shell is defined %}
-    --shell '{{ gitlab_runner.shell }}'
-    {% endif %}
-    --limit '{{ gitlab_runner.concurrent_specific|default(0) }}'
-    --output-limit '{{ gitlab_runner.output_limit|default(4096) }}'
-    --locked='{{ gitlab_runner.locked|default(false) }}'
-    {% for env_var in gitlab_runner.env_vars|default([]) %}
-    --env '{{ env_var }}'
-    {% endfor %}
-    {% if gitlab_runner.pre_clone_script|default(false) %}
-    --pre-clone-script "{{ gitlab_runner.pre_clone_script }}"
-    {% endif %}
-    {% if gitlab_runner.pre_build_script|default(false) %}
-    --pre-build-script "{{ gitlab_runner.pre_build_script }}"
-    {% endif %}
-    {% if gitlab_runner.tls_ca_file|default(false) %}
-    --tls-ca-file "{{ gitlab_runner.tls_ca_file }}"
-    {% endif %}
-    {% if gitlab_runner.post_build_script|default(false) %}
-    --post-build-script "{{ gitlab_runner.post_build_script }}"
-    {% endif %}
-    --docker-image '{{ gitlab_runner.docker_image|default("alpine") }}'
-    {% if gitlab_runner.docker_privileged|default(false) %}
-    --docker-privileged
-    {% endif %}
-    {% for volume in gitlab_runner.docker_volumes | default([]) %}
-    --docker-volumes "{{ volume }}"
-    {% endfor %}
-    {% for device in gitlab_runner.docker_devices | default([]) %}
-    --docker-devices "{{ device }}"
-    {% endfor %}
-    {% if gitlab_runner.ssh_user is defined %}
-    --ssh-user '{{ gitlab_runner.ssh_user }}'
-    {% endif %}
-    {% if gitlab_runner.ssh_host is defined %}
-    --ssh-host '{{ gitlab_runner.ssh_host }}'
-    {% endif %}
-    {% if gitlab_runner.ssh_port is defined %}
-    --ssh-port '{{ gitlab_runner.ssh_port }}'
+    {% if gitlab_runner.cache_s3_secret_key is defined %}
+    --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
     {% endif %}
     {% if gitlab_runner.ssh_password is defined %}
     --ssh-password '{{ gitlab_runner.ssh_password }}'
     {% endif %}
-    {% if gitlab_runner.ssh_identity_file is defined %}
-    --ssh-identity-file '{{ gitlab_runner.ssh_identity_file }}'
-    {% endif %}
-    {% if gitlab_runner.cache_type is defined %}
-    --cache-type '{{ gitlab_runner.cache_type }}'
-    {% endif %}
-    {% if gitlab_runner.cache_shared|default(false) %}
-    --cache-shared
-    {% endif %}
-    {% if gitlab_runner.cache_path is defined %}
-    --cache-path '{{ gitlab_runner.cache_path }}'
-    {% endif %}
-    {% if gitlab_runner.cache_s3_server_address is defined %}
-    --cache-s3-server-address '{{ gitlab_runner.cache_s3_server_address }}'
-    {% endif %}
-    {% if gitlab_runner.cache_s3_access_key is defined %}
-    --cache-s3-access-key '{{ gitlab_runner.cache_s3_access_key }}'
-    {% endif %}
-    {% if gitlab_runner.cache_s3_secret_key is defined %}
-    --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
-    {% endif %}
-    {% if gitlab_runner.cache_s3_bucket_name is defined %}
-    --cache-s3-bucket-name '{{ gitlab_runner.cache_s3_bucket_name }}'
-    {% endif %}
-    {% if gitlab_runner.cache_s3_bucket_location is defined %}
-    --cache-s3-bucket-location '{{ gitlab_runner.cache_s3_bucket_location }}'
-    {% endif %}
-    {% if gitlab_runner.builds_dir|default(false) %}
-    --builds-dir '{{ gitlab_runner.builds_dir }}'
-    {% endif %}
-    {% if gitlab_runner.cache_dir|default(false) %}
-    --cache-dir '{{ gitlab_runner.cache_dir }}'
-    {% endif %}
-    {% if gitlab_runner.cache_s3_insecure|default(false) %}
-    --cache-s3-insecure
-    {% endif %}
-    {% if gitlab_runner.extra_registration_option is defined %}
-    {{ gitlab_runner.extra_registration_option }}
-    {% endif %}
-  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) not in configured_runners.stderr and
+  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string) + ' ') not in configured_runners.stderr and
         gitlab_runner.state|default('present') == 'present'
   args:
     chdir: "{{ gitlab_runner_config_file_location }}"

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -9,13 +9,12 @@
   when: force_accept_gitlab_server_self_signed
 
 - name: Construct the runner command without secrets
-  # makes the command visible in awx without the secrets and therefore helps with debugging
   set_fact:
-    command: >
+    register_runner_cmd: >
       {{ gitlab_runner_executable }} register
       --non-interactive
       --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
-      --description '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
+      --name '{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
       --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
       {% if gitlab_runner.clone_url|default(false) %}
       --clone-url "{{ gitlab_runner.clone_url }}"
@@ -132,15 +131,53 @@
       {{ gitlab_runner.extra_registration_option }}
       {% endif %}
 
+- name: Apply updates (if any) by unregister the runner and let it then register later on
+  block:
+    - name: Check if the configuration has changed since the last run
+      ansible.builtin.copy:
+        content: >
+          {{ register_runner_cmd }}
+          --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
+          {% if gitlab_runner.cache_s3_secret_key is defined %}
+          --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key|hash("sha1") }}'
+          {% endif %}
+          {% if gitlab_runner.ssh_password is defined %}
+          --ssh-password '{{ gitlab_runner.ssh_password|hash("sha1") }}'
+          {% endif %}
+        dest: '{{ gitlab_runner_config_file_location }}/last-runner-config-{{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
+      register: runner_config_state
+
+    - name: List configured runners
+      command: "{{ gitlab_runner_executable }} list"
+      register: configured_runners
+      changed_when: False
+      check_mode: no
+      become: "{{ gitlab_runner_system_mode }}"
+
+    - name: Unregister runner when config has changed
+      ansible.builtin.command: '{{ gitlab_runner_executable }} unregister --name {{ gitlab_runner.name|default(ansible_hostname+"-"+gitlab_runner_index|string) }}'
+      when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string) + ' ') in configured_runners.stderr and
+            runner_config_state.changed
+  when: gitlab_runner_config_update_mode == 'by_registering'
+
+- name: List configured runners again
+  command: "{{ gitlab_runner_executable }} list"
+  register: configured_runners
+  changed_when: False
+  check_mode: no
+  become: "{{ gitlab_runner_system_mode }}"
+
 - name: Register runner to GitLab
   command: >
-    {{ command }}
+    {{ register_runner_cmd }}
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
     {% if gitlab_runner.cache_s3_secret_key is defined %}
     --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
     {% endif %}
-    --ssh-password '{{ gitlab_runner.ssh_password|default("") }}'
-  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)) not in configured_runners.stderr and
+    {% if gitlab_runner.ssh_password is defined %}
+    --ssh-password '{{ gitlab_runner.ssh_password }}'
+    {% endif %}
+  when: ('\n' + gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string) + ' ') not in configured_runners.stderr and
         gitlab_runner.state|default('present') == 'present'
   no_log: true
   become: "{{ gitlab_runner_system_mode }}"


### PR DESCRIPTION
Hi, I know this PR is quite extreme but maybe we use it as a discussion base:

### Current way this role works
From a high level, this role does
* Registering runners (Windows, Linux, Container)
* Apply config changes to the `config.toml`

### Our Motivation
We have a lot of VMs where each of them contains quite some runners (with different tags and settings).
Because of that, this role runs for ages even if no updates are done. Actually it runs that long that it exceeds the
default Ansible timeout of 1 hour.

Furthermore we play around with tags quite often, but this is problematic because this role currently doesn't support tag updates (because tags are not reflected in the `config.toml`

### This PR
To overcome the issues above, I changed the way this role handles config updates. 
* Whenever a runner is registered, the registration command (with hashed secrets) is written to a file (lets call it new-magic-config-file) next to the `config.toml`.
* Whenever the `new-magic-config-file` changes means that the config was updated
* Config updates will trigger an unregister of the runner followed by a register with the latest config
* If the config doesn't change, the `new-magic-config-file` is not updated and therefore the runner won't be touched

### The good
The new way of handling config changes to the runner 
* reduces the amount of "code" in this role drastically which makes it easier
* the role is very fast in both situations with and without config changes
* changes to the tags are also handled properly

### The bad
The biggest drawback of this PR is, that the registration token is now mandatory. It is not longer possible to simply updated the config of the runner without the token.


---

@riemers  what do you think of this? 

It is not fully finished yet. The Windows and Docker stuff must be tested first, because I only checked the Linux part and changed the Windows and  Docker parts untested. 