### PR TITLE
docs: document docker_wait_for_services_timeout

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,8 @@ gitlab_runner_runners:
     locked: 'false'
     # Add container to a custom network
     docker_network_mode: bridge
+    # Change the services startup timeout
+    # docker_wait_for_services_timeout: 30
     # Custom CA certificate file
     # tls_ca_file: "/etc/ssl/private/Custom_Bundle-CA.pem"
     #


### PR DESCRIPTION
Document `docker_wait_for_services_timeout` variable.

I was setting this option using `extra_configs` because I couldn't find a dedicated variable to set. However, doing so will actually cause a change on every run because the default will be re-written just for the extra config to correct it again.