### PR TITLE
Add mutual TLS (mTLS/client side TLS) options to the configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,6 +108,10 @@ gitlab_runner_runners:
     # docker_wait_for_services_timeout: 30
     # Custom CA certificate file
     # tls_ca_file: "/etc/ssl/private/Custom_Bundle-CA.pem"
+    # Client certificate file to (mTLS) authenticate with the peer
+    # tls_cert_file: "/etc/gitlab-runner/ssl/gitlab-runner.cert.pem"
+    # Client certificate's key file to (mTLS) authenticate with the peer
+    # tls_key_file: "/etc/gitlab-runner/ssl/gitlab-runner.key.pem"
     #
     # Custom environment variables injected to build environment
     env_vars: []

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -331,6 +331,32 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
+- name:  "{{ runn_name_prefix }} Set tls-cert-file option"
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*tls-cert-file ='
+    line: '  tls-cert-file = {{ gitlab_runner.tls_cert_file|default([]) | to_json }}'
+    state: "{{ 'present' if gitlab_runner.tls_cert_file is defined else 'absent' }}"
+    insertafter: '^\s*url ='
+    backrefs: no
+  check_mode: no
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
+
+- name:  "{{ runn_name_prefix }} Set tls-key-file option"
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*tls-key-file ='
+    line: '  tls-key-file = {{ gitlab_runner.tls_key_file|default([]) | to_json }}'
+    state: "{{ 'present' if gitlab_runner.tls_key_file is defined else 'absent' }}"
+    insertafter: '^\s*url ='
+    backrefs: no
+  check_mode: no
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
+
 #### [[runners.docker.services]] section ####
 - name:  "{{ runn_name_prefix }} Set additional services"
   blockinfile:


### PR DESCRIPTION
When the (self-hosted) gitlab instance requires the clients to authenticate when connecting via HTTPS, it is necessary to define certificate and key files for the runners too to be used.

See: https://docs.gitlab.com/runner/configuration/advanced-configuration.html