### PR TITLE
fix debian idempotence

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -59,6 +59,7 @@
     name: "{{ gitlab_runner_package_name }}"
     selection: hold
   when: gitlab_runner_package_version is defined
+  changed_when: false
 
 - name: (Debian) Remove ~/gitlab-runner/.bash_logout on debian buster and ubuntu focal
   file:


### PR DESCRIPTION
The role unholds and holds the gitlab-runner version in Debian. Idempotence always reported the holding as changed.