### PR TITLE
Remove spurious newline in middle of command

### DIFF
--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -2,7 +2,7 @@
 
 - name: Construct the runner command without secrets
   set_fact:
-    register_runner_cmd: >
+    register_runner_cmd: >-
       register
       --non-interactive
       --url '{{ gitlab_runner.url | default(gitlab_runner_coordinator_url) }}'

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -2,7 +2,7 @@
 
 - name: Construct the runner command without secrets
   set_fact:
-    register_runner_cmd: >
+    register_runner_cmd: >-
       {{ gitlab_runner_executable }} register
       --non-interactive
       --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -10,7 +10,7 @@
 
 - name: Construct the runner command without secrets
   set_fact:
-    register_runner_cmd: >
+    register_runner_cmd: >-
       {{ gitlab_runner_executable }} register
       --non-interactive
       --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'


### PR DESCRIPTION
When `register_runner_cmd` is put together to be run the `>` mode of Yaml puts a newline at the end of the string. This breaks the command.

Using `>-` removes this newline.