### PR TITLE
Avoid over escaping

### DIFF
--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -28,16 +28,16 @@
       --env '{{ env_var }}'
       {% endfor %}
       {% if gitlab_runner.pre_clone_script|default(false) %}
-      --pre-clone-script "{{ gitlab_runner.pre_clone_script }}"
+      --pre-clone-script '{{ gitlab_runner.pre_clone_script }}'
       {% endif %}
       {% if gitlab_runner.pre_build_script|default(false) %}
-      --pre-build-script "{{ gitlab_runner.pre_build_script }}"
+      --pre-build-script '{{ gitlab_runner.pre_build_script }}'
       {% endif %}
       {% if gitlab_runner.tls_ca_file|default(false) %}
       --tls-ca-file "{{ gitlab_runner.tls_ca_file }}"
       {% endif %}
       {% if gitlab_runner.post_build_script|default(false) %}
-      --post-build-script "{{ gitlab_runner.post_build_script }}"
+      --post-build-script '{{ gitlab_runner.post_build_script }}'
       {% endif %}
       --docker-image '{{ gitlab_runner.docker_image|default("alpine") }}'
       {% if gitlab_runner.docker_privileged|default(false) %}


### PR DESCRIPTION
When running the registration command with a `pre-build-script` the argument parameter is getting over-escaped, e.g.:
```
 --executor 'docker-windows'  --limit '0' --output-limit '20480' --locked='False'    --pre-build-script \"cmd /c \"echo
```

Because my command uses redirection this then feeds into the ansible command and produces an error.

Changing to use single quotes for the command arg avoid this, producing:
```
 --executor 'docker-windows'  --limit '0' --output-limit '20480' --locked='False'    --pre-build-script 'cmd /c \"echo
```

I'm not sure if it's the best fix, maybe some escaping filter should be used instead.