### PR TITLE
Remove not longer configured runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ On Linux, use `gitlab_runner_package_version` instead.
 - `gitlab_runner_runners` - A list of gitlab runners to register & configure. Defaults to a single shell executor.
 - `gitlab_runner_skip_package_repo_install`- Skip the APT or YUM repository installation (by default, false). You should provide a repository containing the needed packages before running this role.
 - `gitlab_runner_config_update_mode`- Set to `by_config_toml` (default) if this role should apply config changes by updating the `config.toml` itself or set it to `by_registering` if config changes should be applied by unregistering and regeistering the runner in case the config has changed.
+- `gitlab_unregister_runner_executors_which_are_not_longer_configured` - Set to `true` if executors should be unregistered from a runner in case it is are not longer configured in ansible. Default: `false`
 
 See the [`defaults/main.yml`](https://github.com/riemers/ansible-gitlab-runner/blob/master/defaults/main.yml) file listing all possible options which you can be passed to a runner registration command.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,7 @@ gitlab_runner_session_server_session_timeout: 1800
 # gitlab_runner_skip_package_repo_install: true
 
 gitlab_runner_config_update_mode: by_config_toml
+gitlab_unregister_runner_executors_which_are_not_longer_configured: false
 
 # The credentials for the Windows user used to run the gitlab-runner service.
 # Those credentials will be passed to `gitlab-runner.exe install`.

--- a/tasks/main-container.yml
+++ b/tasks/main-container.yml
@@ -20,6 +20,8 @@
   changed_when: '"Updated " in verified_runners.container.Output'
   check_mode: no
 
+- import_tasks: list-configured-runners-container.yml
+
 - name: (Container) Register GitLab Runner
   include_tasks: register-runner-container.yml
   vars:
@@ -29,6 +31,10 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
+
+- name: Unregister runners which are not longer configured
+  include_tasks: unregister-runner-if-not-longer-configured.yml
+  when: gitlab_unregister_runner_executors_which_are_not_longer_configured
 
 - name: (Container) Set global options
   import_tasks: global-setup.yml

--- a/tasks/main-unix.yml
+++ b/tasks/main-unix.yml
@@ -1,17 +1,17 @@
 - name: Install GitLab Runner (Debian)
-  import_tasks: install-debian.yml
+  include_tasks: install-debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Install GitLab Runner (RedHat)
-  import_tasks: install-redhat.yml
+  include_tasks: install-redhat.yml
   when: ansible_os_family == 'RedHat'
 
 - name: Install GitLab Runner (macOS)
-  import_tasks: install-macos.yml
+  include_tasks: install-macos.yml
   when: ansible_os_family == 'Darwin'
 
 - name: Install GitLab Runner (Arch)
-  import_tasks: install-arch.yml
+  include_tasks: install-arch.yml
   when: ansible_os_family == 'Archlinux'
 
 - name: (Unix) Delete runners which were removed in GitLab

--- a/tasks/main-unix.yml
+++ b/tasks/main-unix.yml
@@ -21,6 +21,8 @@
   check_mode: no
   become: "{{ gitlab_runner_system_mode }}"
 
+- import_tasks: list-configured-runners-unix.yml
+
 - name: (Unix) Register GitLab Runner
   include_tasks: register-runner.yml
   vars:
@@ -30,6 +32,10 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
+
+- name: Unregister runners which are not longer configured
+  include_tasks: unregister-runner-if-not-longer-configured.yml
+  when: gitlab_unregister_runner_executors_which_are_not_longer_configured
 
 - name: Set global options (macOS/Debian/RedHat)
   import_tasks: global-setup.yml

--- a/tasks/main-windows.yml
+++ b/tasks/main-windows.yml
@@ -9,6 +9,8 @@
   changed_when: '"Updated " in verified_runners.stderr'
   check_mode: no
 
+- import_tasks: list-configured-runners-windows.yml
+
 - name: (Windows) Register GitLab Runner
   include_tasks: register-runner-windows.yml
   vars:
@@ -18,6 +20,10 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
+
+- name: Unregister runners which are not longer configured
+  include_tasks: unregister-runner-if-not-longer-configured.yml
+  when: gitlab_unregister_runner_executors_which_are_not_longer_configured
 
 - name: (Windows) Set global options
   import_tasks: global-setup-windows.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,13 +11,19 @@
         - 'vars'
 
 - name: Install Gitlab Runner (Container)
+  vars:
+    gitlab_install_target_platform: container
   include_tasks: main-container.yml
   when: gitlab_runner_container_install
 
 - name: Install GitLab Runner (Unix)
+  vars:
+    gitlab_install_target_platform: unix
   include_tasks: main-unix.yml
   when: ansible_os_family != 'Windows' and not gitlab_runner_container_install
 
 - name: Install GitLab Runner (Windows)
+  vars:
+    gitlab_install_target_platform: windows
   include_tasks: main-windows.yml
   when: ansible_os_family == 'Windows' and not gitlab_runner_container_install

--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -106,24 +106,8 @@
         dest: '{{ gitlab_runner_config_file_location }}/last-runner-config-{{ actual_gitlab_runner_name }}'
       register: runner_config_state
 
-    - import_tasks: list-configured-runners-container.yml
-
-    - name: Unregister runner when config has changed
-      docker_container:
-        name: "{{ gitlab_runner_container_name }}-list"
-        image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
-        command: unregister --name {{ actual_gitlab_runner_name }}'
-        mounts:
-          - type: bind
-            source: "{{ gitlab_runner_container_mount_path }}"
-            target: /etc/gitlab-runner
-        cleanup: yes
-        interactive: yes
-        tty: yes
-        detach: no
-      changed_when: False
-      check_mode: no
-      when: 
+    - import_tasks: unregister-runner.yml
+      when:
         - actual_gitlab_runner_name in registered_gitlab_runner_names
         - runner_config_state.changed
   when: gitlab_runner_config_update_mode == 'by_registering'

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -105,12 +105,7 @@
         dest: '{{ gitlab_runner_config_file_location }}/last-runner-config-{{ actual_gitlab_runner_name }}'
       register: runner_config_state
 
-    - import_tasks: list-configured-runners-windows.yml
-
-    - name: (Windows) Unregister runner when config has changed
-      win_command: '{{ gitlab_runner_executable }} unregister --name {{ actual_gitlab_runner_name }}'
-      args:
-        chdir: "{{ gitlab_runner_config_file_location }}"
+    - import_tasks: unregister-runner.yml
       when:
         - actual_gitlab_runner_name in registered_gitlab_runner_names
         - runner_config_state.changed

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -141,11 +141,8 @@
         dest: '{{ gitlab_runner_config_file_location }}/last-runner-config-{{ actual_gitlab_runner_name }}'
       register: runner_config_state
 
-    - import_tasks: list-configured-runners-unix.yml
-
-    - name: Unregister runner when config has changed
-      ansible.builtin.command: '{{ gitlab_runner_executable }} unregister --name {{ actual_gitlab_runner_name }}'
-      when: 
+    - import_tasks: unregister-runner.yml
+      when:
         - actual_gitlab_runner_name in registered_gitlab_runner_names
         - runner_config_state.changed
   when: gitlab_runner_config_update_mode == 'by_registering'

--- a/tasks/unregister-runner-if-not-longer-configured.yml
+++ b/tasks/unregister-runner-if-not-longer-configured.yml
@@ -1,0 +1,18 @@
+
+- name: Get the names of all configured runner executors
+  set_fact:
+    local_gitlab_executor_names: "{{ gitlab_runner_runners | map(attribute='name') | list }}"
+
+- name: Find all executors which are not longer configured in ansible
+  set_fact:
+    available_runners_not_longer_configured: "{{ registered_gitlab_runner_names | difference(local_gitlab_executor_names) }}"
+
+- name: These runners are going to be unregistered
+  debug: var=available_runners_not_longer_configured
+  when: available_runners_not_longer_configured | length > 0
+
+- include_tasks: unregister-runner.yml
+  loop: "{{ available_runners_not_longer_configured }}"
+  loop_control:
+    loop_var: actual_gitlab_runner_name
+  when: available_runners_not_longer_configured | length > 0

--- a/tasks/unregister-runner.yml
+++ b/tasks/unregister-runner.yml
@@ -1,0 +1,34 @@
+
+
+
+- name: (Container) Unregister runner
+  docker_container:
+    name: "{{ gitlab_runner_container_name }}-list"
+    image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
+    command: unregister --name {{ actual_gitlab_runner_name }}'
+    mounts:
+      - type: bind
+        source: "{{ gitlab_runner_container_mount_path }}"
+        target: /etc/gitlab-runner
+    cleanup: yes
+    interactive: yes
+    tty: yes
+    detach: no
+  changed_when: False
+  check_mode: no
+  when: 
+    - gitlab_install_target_platform == 'container'
+
+
+- name: (Windows) Unregister runner
+  win_command: '{{ gitlab_runner_executable }} unregister --name {{ actual_gitlab_runner_name }}'
+  args:
+    chdir: "{{ gitlab_runner_config_file_location }}"
+  when:
+    - gitlab_install_target_platform == 'windows'
+
+
+- name: Unregister runner
+  ansible.builtin.command: '{{ gitlab_runner_executable }} unregister --name {{ actual_gitlab_runner_name }}'
+  when: 
+    - gitlab_install_target_platform == 'unix'


### PR DESCRIPTION
When a runner executor is registered in gitlab but not longer configured in ansible, currently the executor was untouched because it it not known by this role. Now there is a new flag whcih controls if such executors should be unregisterd, in case they are not longer configured in ansible.