### PR TITLE
Add a `gitlab_runner_no_log_secrets` option to prevent secret leaks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,7 +80,7 @@ gitlab_runner_restart_state: restarted
 # default value for force accept self signed certificates
 force_accept_gitlab_server_self_signed: false
 
-# controls diffs for assemle config file
+# controls diffs for assemble config file
 gitlab_runner_show_config_diff: no
 
 # controls logs on ansible configuration tasks, uncomment to prevent secret leaks (Unix support only).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,6 +83,9 @@ force_accept_gitlab_server_self_signed: false
 # controls diffs for assemle config file
 gitlab_runner_show_config_diff: no
 
+# controls logs on ansible configuration tasks, uncomment to prevent secret leaks (Unix support only).
+# gitlab_runner_no_log_secrets: yes
+
 # A list of runners to register and configure
 gitlab_runner_runners:
     # The identifier of the runner.

--- a/tasks/config-runner.yml
+++ b/tasks/config-runner.yml
@@ -15,6 +15,7 @@
     content: "{{ runner_config }}"
   check_mode: no
   changed_when: false
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
 
 - include_tasks: update-config-runner.yml
   vars:
@@ -26,6 +27,7 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
 
 - name: "{{ conf_name_prefix }} Remove runner config"
   file:
@@ -38,3 +40,4 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"

--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -8,6 +8,7 @@
 - name: Get pre-existing runner configs
   set_fact:
     runner_configs: "{{ (runner_config_file['content'] | b64decode).split('[[runners]]\n') }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
 
 - name: Create temporary directory
   tempfile:
@@ -25,6 +26,7 @@
   loop_control:
     index_var: runner_config_index
     loop_var: runner_config
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
 
 - name: Assemble new config.toml
   assemble:

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -21,6 +21,7 @@
     line: '\1concurrent = {{ gitlab_runner_concurrent }}'
     state: present
     backrefs: yes
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
@@ -33,6 +34,7 @@
     line: 'listen_address = "{{ gitlab_runner_listen_address }}"'
     insertafter: '\s*concurrent.*'
     state: present
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   when: gitlab_runner_listen_address | length > 0  # Ensure value is set
   become: "{{ gitlab_runner_system_mode }}"
   notify:
@@ -46,6 +48,7 @@
     line: 'log_format = "{{ gitlab_runner_log_format|default("runner") }}"'
     insertbefore: BOF
     state: present
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   when: gitlab_runner_log_format is defined # Ensure value is set
   become: "{{ gitlab_runner_system_mode }}"
   notify:
@@ -59,6 +62,7 @@
     line: 'sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"'
     insertafter: '\s*concurrent.*'
     state: present
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   when: gitlab_runner_sentry_dsn | length > 0  # Ensure value is set
   become: "{{ gitlab_runner_system_mode }}"
   notify:
@@ -72,6 +76,7 @@
     line: '  listen_address = "{{ gitlab_runner_session_server_listen_address }}"'
     insertafter: '^\s*\[session_server\]'
     state: "{{ 'present' if gitlab_runner_session_server_listen_address | length > 0 else 'absent' }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
@@ -85,6 +90,7 @@
     insertafter: '^\s*\[session_server\]'
     state: "{{ 'present' if gitlab_runner_session_server_advertise_address | length > 0 else 'absent' }}"
   become: "{{ gitlab_runner_system_mode }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -96,6 +102,7 @@
     line: "  session_timeout = {{ gitlab_runner_session_server_session_timeout }}"
     insertafter: '^\s*\[session_server\]'
     state: present
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   when: gitlab_runner_session_server_session_timeout
   become: "{{ gitlab_runner_system_mode }}"
   notify:

--- a/tasks/main-unix.yml
+++ b/tasks/main-unix.yml
@@ -32,6 +32,7 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
 
 - name: Unregister runners which are not longer configured
   include_tasks: unregister-runner-if-not-longer-configured.yml

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -8,6 +8,7 @@
     insertafter: '^\s*name ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -21,6 +22,7 @@
     insertafter: '^\s*limit ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -34,6 +36,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -48,6 +51,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -61,6 +65,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -75,6 +80,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -89,6 +95,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -103,6 +110,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -117,6 +125,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -130,6 +139,7 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -143,6 +153,7 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -156,6 +167,7 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -171,6 +183,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -184,6 +197,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -197,6 +211,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -210,6 +225,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -223,6 +239,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -236,6 +253,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -249,6 +267,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -262,6 +281,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -275,6 +295,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -288,6 +309,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -301,6 +323,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -314,6 +337,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -327,6 +351,7 @@
     insertafter: '^\s*\[runners\.docker\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -340,6 +365,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -353,6 +379,7 @@
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -366,6 +393,7 @@
     marker: "# {mark} runners.docker.services"
     insertafter: EOF
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -380,6 +408,7 @@
     insertafter: EOF
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -393,6 +422,7 @@
     insertafter: '^\s*\[runners\.custom_build_dir\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -407,6 +437,7 @@
     insertafter: EOF
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -420,6 +451,7 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -433,6 +465,7 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -446,6 +479,7 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -459,6 +493,7 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -472,6 +507,7 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -485,6 +521,7 @@
     insertafter: '^\s*\[runners\.cache\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -500,6 +537,7 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -513,6 +551,7 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -526,6 +565,7 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -539,6 +579,7 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -553,6 +594,7 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -566,6 +608,7 @@
     insertafter: '^\s*\[runners\.cache\.s3\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -595,6 +638,7 @@
     insertafter: '^\s*\[runners\.cache\.gcs\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -608,6 +652,7 @@
     insertafter: '^\s*\[runners\.cache\.gcs\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -621,6 +666,7 @@
     insertafter: '^\s*\[runners\.cache\.gcs\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -635,6 +681,7 @@
     insertafter: '^\s*\[runners\.cache\.azure\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -648,6 +695,7 @@
     insertafter: '^\s*\[runners\.cache\.azure\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -661,6 +709,7 @@
     insertafter: '^\s*\[runners\.cache\.azure\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -674,6 +723,7 @@
     insertafter: '^\s*\[runners\.cache\.azure\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -688,6 +738,7 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -701,6 +752,7 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -714,6 +766,7 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -727,6 +780,7 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -740,6 +794,7 @@
     insertafter: '^\s*\[runners\.ssh\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -754,6 +809,7 @@
     insertafter: '^\s*\[runners\.virtualbox\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   when: gitlab_runner.executor == 'virtualbox' and gitlab_runner.virtualbox_base_name is defined
   notify:
   - restart_gitlab_runner
@@ -768,6 +824,7 @@
     insertafter: '^\s*\[runners\.virtualbox\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   when: gitlab_runner.executor == 'virtualbox' and gitlab_runner.virtualbox_base_name is defined
   notify:
   - restart_gitlab_runner
@@ -783,6 +840,7 @@
     backrefs: no
   check_mode: no
   when: gitlab_runner.executor == 'virtualbox' and gitlab_runner.virtualbox_base_name is defined
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -796,6 +854,7 @@
     insertafter: '^\s*\[runners\.virtualbox\]'
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   when: gitlab_runner.executor == 'virtualbox' and gitlab_runner.virtualbox_base_name is defined
   notify:
   - restart_gitlab_runner
@@ -810,6 +869,7 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
@@ -823,6 +883,7 @@
     insertafter: '^\s*executor ='
     backrefs: no
   check_mode: no
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos


### PR DESCRIPTION
## Goal

Ensure no secrets will leaks when running `ansible`.

## Implementation

Add a new option that is not defined by default, adding this option will mute a lot of config tasks output.

⚠️ This setup is only done for unix runners, I don't have any windows machine to test

## Test

- add a S3 cache section with credentials
- run `ansible-playbook` with `-vvvv` arg
- look for credentials in output 👀 💥 
- define `gitlab_runner_no_log_secrets: yes` and run again
- look for credentials in output 👀 ✅ 

## Note

Thanks for your role it does exactly what I was looking for !
I just need this feature to use it for production purposes.
