### PR TITLE
Add support for `post_get_sources_script`, replace deprecated `pre_clone_script` with `pre_get_sources_script`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -127,8 +127,8 @@ gitlab_runner_runners:
     # Sets the clone_url. The default is not set.
     # clone_url:
     #
-    # Sets the pre_clone_script. The default is not set.
-    # pre_clone_script:
+    # Sets the pre_get_sources_script. The default is not set.
+    # pre_get_sources_script:
     #
     # Sets the pre_build_script. The default is not set.
     # pre_build_script:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -130,6 +130,9 @@ gitlab_runner_runners:
     # Sets the pre_get_sources_script. The default is not set.
     # pre_get_sources_script:
     #
+    # Sets the post_get_sources_script.  The default is not set.
+    # post_get_sources_script:
+    #
     # Sets the pre_build_script. The default is not set.
     # pre_build_script:
     #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,16 @@
       paths:
         - 'vars'
 
+- name: Validate GitLab Runner configurations
+  include_tasks: validate-runner-config.yml
+  vars:
+    actual_gitlab_runner_name: "{{ gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string) }}"
+  loop: "{{ gitlab_runner_runners }}"
+  loop_control:
+    label: "{{ actual_gitlab_runner_name }}"
+    index_var: gitlab_runner_index
+    loop_var: gitlab_runner
+
 - name: Install Gitlab Runner (Container)
   vars:
     gitlab_install_target_platform: container

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -67,6 +67,18 @@
   notify: restart_gitlab_runner
   when: gitlab_runner.pre_get_sources_script is defined
 
+- name: "(Windows) {{ runn_name_prefix }} Set post_get_sources_script"
+  win_lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*post_get_sources_script ='
+    line: '  post_get_sources_script = {{ gitlab_runner.post_get_sources_script | to_json }}'
+    state: present
+    insertafter: '^\s*url ='
+    backrefs: no
+  check_mode: no
+  notify: restart_gitlab_runner
+  when: gitlab_runner.post_get_sources_script is defined
+
 - name: "(Windows) {{ runn_name_prefix }} Set pre_build_script"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -55,17 +55,17 @@
   check_mode: no
   notify: restart_gitlab_runner_windows
 
-- name: "(Windows) {{ runn_name_prefix }} Set pre_clone_script"
+- name: "(Windows) {{ runn_name_prefix }} Set pre_get_sources_script"
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
-    regexp: '^\s*pre_clone_script ='
-    line: '  pre_clone_script = {{ gitlab_runner.pre_clone_script | to_json }}'
+    regexp: '^\s*pre_get_sources_script ='
+    line: '  pre_get_sources_script = {{ gitlab_runner.pre_get_sources_script | to_json }}'
     state: present
     insertafter: '^\s*url ='
     backrefs: no
   check_mode: no
   notify: restart_gitlab_runner
-  when: gitlab_runner.pre_clone_script is defined
+  when: gitlab_runner.pre_get_sources_script is defined
 
 - name: "(Windows) {{ runn_name_prefix }} Set pre_build_script"
   win_lineinfile:

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -52,11 +52,11 @@
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
 
-- name:  "{{ runn_name_prefix }} Set pre_clone_script"
+- name:  "{{ runn_name_prefix }} Set pre_get_sources_script"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
-    regexp: '^\s*pre_clone_script ='
-    line: '  pre_clone_script = {{ gitlab_runner.pre_clone_script | to_json }}'
+    regexp: '^\s*pre_get_sources_script ='
+    line: '  pre_get_sources_script = {{ gitlab_runner.pre_get_sources_script | to_json }}'
     state: present
     insertafter: '^\s*url ='
     backrefs: no
@@ -64,7 +64,7 @@
   notify:
   - restart_gitlab_runner
   - restart_gitlab_runner_macos
-  when: gitlab_runner.pre_clone_script is defined
+  when: gitlab_runner.pre_get_sources_script is defined
 
 - name:  "{{ runn_name_prefix }} Set pre_build_script"
   lineinfile:

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -66,6 +66,20 @@
   - restart_gitlab_runner_macos
   when: gitlab_runner.pre_get_sources_script is defined
 
+- name:  "{{ runn_name_prefix }} Set post_get_sources_script"
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: '^\s*post_get_sources_script ='
+    line: '  post_get_sources_script = {{ gitlab_runner.post_get_sources_script | to_json }}'
+    state: present
+    insertafter: '^\s*url ='
+    backrefs: no
+  check_mode: no
+  notify:
+  - restart_gitlab_runner
+  - restart_gitlab_runner_macos
+  when: gitlab_runner.post_get_sources_script is defined
+
 - name:  "{{ runn_name_prefix }} Set pre_build_script"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/tasks/validate-runner-config.yml
+++ b/tasks/validate-runner-config.yml
@@ -1,0 +1,13 @@
+---
+- name: "Check for deprecated settings: {{ actual_gitlab_runner_name }}"
+  ansible.builtin.assert:
+    that:
+      - "'{{ setting.name }}' not in gitlab_runner"
+    fail_msg: "DEPRECATED setting for runner {{ actual_gitlab_runner_name }}: {{ setting.name }} - {{ setting.message }}"
+    quiet: true
+  loop:
+    - name: pre_clone_script
+      message: use pre_get_sources_script instead
+  loop_control:
+    label: "{{ setting.name }}"
+    loop_var: setting


### PR DESCRIPTION
* Add support for `post_get_sources_script` in the runner config.
* The `pre_clone_script` config option has been deprecated for a while now and is replaced by `pre_get_sources_script`.

See GitLab 16.2 docs: [Advanced Configuration / The [[runners]] section](https://docs.gitlab.com/16.2/runner/configuration/advanced-configuration.html#the-runners-section)