### PR TITLE
Fix deploying to Windows machines

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,10 @@ gitlab_runner_windows_service_password: ''
 # https://docs.gitlab.com/runner/install/osx.html#limitations-on-macos
 gitlab_runner_macos_start_runner: true
 
+# Whether to try to start the runner on Windows.
+# If set to `false`, it should be started manually.
+gitlab_runner_windows_start_runner: true
+
 # default values for gitlab in container
 gitlab_runner_container_install: false
 gitlab_runner_container_image: gitlab/gitlab-runner

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,7 +15,7 @@
   win_command: "{{ gitlab_runner_executable }} restart"
   args:
     chdir: "{{ gitlab_runner_config_file_location }}"
-  when: ansible_os_family == 'Windows'
+  when: ansible_os_family == 'Windows' and gitlab_runner_windows_start_runner
 
 # Container
 - name: restart_gitlab_runner_container

--- a/tasks/list-configured-runners-windows.yml
+++ b/tasks/list-configured-runners-windows.yml
@@ -17,8 +17,8 @@
     registered_gitlab_runner_names: "{{ registered_gitlab_runner_names + [json_item['msg']] }}"
   vars:
     json_item: "{{ item | from_json }}"
-  loop: "{{ registered_runners_json_result.stderr.split('\n') }}"
+  loop: "{{ registered_runners_json_result.stderr_lines }}"
   when: "'Executor' in json_item"
 
-- name: Print configured runners
+- name: Print registered runners
   debug: var=registered_gitlab_runner_names

--- a/tasks/main-windows.yml
+++ b/tasks/main-windows.yml
@@ -36,3 +36,5 @@
   win_command: "{{ gitlab_runner_executable }} start"
   args:
     chdir: "{{ gitlab_runner_config_file_location }}"
+  when: gitlab_runner_windows_start_runner
+  

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -124,7 +124,7 @@
     --ssh-password '{{ gitlab_runner.ssh_password }}'
     {% endif %}
   when:
-    - actual_gitlab_runner_name) not in registered_gitlab_runner_names
+    - actual_gitlab_runner_name not in registered_gitlab_runner_names
     - gitlab_runner.state|default('present') == 'present'
   args:
     chdir: "{{ gitlab_runner_config_file_location }}"

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -172,7 +172,7 @@
   win_lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*network_mode =.*'
-    line: '  network_mode = {{ gitlab_runner.docker_network_mode }}'
+    line: '  network_mode = {{ gitlab_runner.docker_network_mode|default("bridge") | to_json }}'
     state: "{{ 'present' if gitlab_runner.docker_network_mode is defined else 'absent' }}"
     insertafter: '^\s*executor ='
     backrefs: no


### PR DESCRIPTION
It seems the current implementation breaks if there are no configured runners, this brings the window configuration in line with the other Unix configurations.

It seems to work on my side when testing just this included file.