### PR TITLE
Add trim to register_runner_cmd

### DIFF
--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -93,7 +93,7 @@
   block:
     - name: Check if the configuration has changed since the last run
       ansible.builtin.copy:
-        content: >
+        content: >-
           {{ register_runner_cmd }}
           --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
           {% if gitlab_runner.cache_s3_secret_key is defined %}
@@ -114,7 +114,7 @@
 - import_tasks: list-configured-runners-windows.yml
 
 - name: (Windows) Register runner to GitLab
-  win_shell: >
+  win_shell: >-
     {{ register_runner_cmd }}
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
     {% if gitlab_runner.cache_s3_secret_key is defined %}


### PR DESCRIPTION
Using version 1.6.54. Upgrading to latest didnt work out of the box (will look into that later).

When using the role, the variable used on the two changed lines contains a newline character. Which breaks the runner registration. Calling trim like so fixes it. But Im curious why no one else has run across this, feels like it should never work or work all the time.


```
$ pipenv requirements
-i https://pypi.org/simple
ansible==8.3.0
ansible-core==2.15.3 ; python_version >= '3.9'
cffi==1.15.1
cryptography==41.0.3 ; python_version >= '3.7'
importlib-resources==5.0.7 ; python_version < '3.10'
jinja2==3.1.2 ; python_version >= '3.7'
jmespath==1.0.1
markupsafe==2.1.3 ; python_version >= '3.7'
packaging==23.1 ; python_version >= '3.7'
pycparser==2.21
pyyaml==6.0.1 ; python_version >= '3.6'
resolvelib==1.0.1
```