### PR TITLE
Fix Download and update gitlab-runner on MacOS

### DIFF
--- a/tasks/install-macos.yml
+++ b/tasks/install-macos.yml
@@ -69,6 +69,7 @@
         url: "{{ gitlab_runner_download_url }}"
         dest: "{{ gitlab_runner_executable }}"
         force: true
+      become: true
 
     - name: (MacOS) Setting Permissions for gitlab-runner executable
       file:


### PR DESCRIPTION
Hey, it's been a while :)

I do have a small fix for the MacOS part of the role. If fails repeatedly because ansible cannot override the GitLab Runner executable as it is owned by `root`. Replicating the behaviour from the `download` section and using `become` fixes the issues and seems to be the right approach.

Cheers,
Matthias

