### PR TITLE
fix(install-debian.yml): add task to gather package facts before unholding GitLab Runner version

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -30,11 +30,16 @@
     gitlab_runner_package_state: latest
   when: gitlab_runner_package_version is not defined
 
+- name: Gather the package facts
+  package_facts:
+    manager: apt
+
 - name: (Debian) Unhold GitLab Runner version
   changed_when: false
   dpkg_selections:
     name: "{{ gitlab_runner_package_name }}"
     selection: install
+  when: "'gitlab-runner' in ansible_facts.packages"
 
 - name: (Debian) Install GitLab Runner
   apt:


### PR DESCRIPTION
fix(install-debian.yml): add condition to unhold GitLab Runner version only if 'gitlab-runner' package is installed

Fixes #301 