### PR TITLE
fix: run ansible-lint in ci

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,0 +1,16 @@
+---
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+
+jobs:
+  ansible-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint role
+        uses: ansible/ansible-lint@main


### PR DESCRIPTION
Perhaps a good idea to run ansible-lint in the CI to catch potential issues