### PR TITLE
Add support for setting `check_interval`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,10 @@ gitlab_runner_executable: "{{ gitlab_runner_package_name }}"
 # Maximum number of global jobs to run concurrently
 gitlab_runner_concurrent: "{{ ansible_processor_vcpus }}"
 
+# Defines the interval length, in seconds, between the runner checking for new jobs.
+# The default value is 0. If set to 0 or lower, the default value of GitLab runner is used, which is 3.
+gitlab_runner_check_interval: 0
+
 # GitLab coordinator URL
 gitlab_runner_coordinator_url: https://gitlab.com
 # GitLab registration token

--- a/tasks/global-setup-windows.yml
+++ b/tasks/global-setup-windows.yml
@@ -23,6 +23,19 @@
     - restart_gitlab_runner_macos
     - restart_gitlab_runner_windows
 
+- name: (Windows) Set check_interval option
+  lineinfile:
+    dest: "{{ gitlab_runner_config_file }}"
+    regexp: ^check_interval =.*
+    line: check_interval = {{ gitlab_runner_check_interval }}
+    insertafter: \s*concurrent.*
+    state: present
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  become: "{{ gitlab_runner_system_mode }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_windows
+
 - name: (Windows) Add listen_address to config
   win_lineinfile:
     dest: "{{ gitlab_runner_config_file }}"

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -27,6 +27,19 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
+- name: Set check_interval option
+  lineinfile:
+    dest: "{{ gitlab_runner_config_file }}"
+    regexp: ^check_interval =
+    line: check_interval = {{ gitlab_runner_check_interval }}
+    insertafter: \s*concurrent.*
+    state: present
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  become: "{{ gitlab_runner_system_mode }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
+
 - name: Add listen_address to config
   lineinfile:
     dest: "{{ gitlab_runner_config_file }}"


### PR DESCRIPTION
Add support to set `check_interval` in the global config section.

> `check_interval`: Defines the interval length, in seconds, between the runner checking for new jobs.
> The default value is `3`. If set to `0` or lower, the default value is used.

See https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section

This defaults to `0` which matches the default auto-generated config, and simply causes GitLab runner to use its default value (see above). So this shouldn't cause any change in behaviour for existing users of this role.