### PR TITLE
Add support for docker tmpfs options

### DIFF
--- a/tasks/line-config-runner.yml
+++ b/tasks/line-config-runner.yml
@@ -12,7 +12,7 @@
     regexp: ^(\s*)({{ line | regex_escape }}|{{ line | regex_escape }}) =
     line: '{{ "  " * (section.split(".")|length) }}{{ line }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
   register: modified_config_line
-  when: not '.' in line
+  when: "not '.' in line and not '/' in line"
 
 - name: "{{ line_name_prefix }} Modify existing line to_json"
   lineinfile:
@@ -21,4 +21,4 @@
     regexp: ^(\s*)({{ line | to_json | regex_escape }}|{{ line | regex_escape }}) =
     line: '{{ "  " * (section.split(".")|length) }}{{ line | to_json }} = {{ gitlab_runner.extra_configs[section][line] | to_json }}'
   register: modified_config_line
-  when: "'.' in line"
+  when: "'.' in line or '/' in line"


### PR DESCRIPTION
Fixing #302 

The configuration of a docker tmpfs option contains slashes and must be converted to json.

https://docs.gitlab.com/runner/executors/docker.html#mount-a-directory-in-ram