### PR TITLE
Fixing GitLab Runner Re-Install and missing /usr/bin/test

### DIFF
--- a/tasks/install-macos.yml
+++ b/tasks/install-macos.yml
@@ -64,7 +64,8 @@
     - name: (MacOS) Stop GitLab Runner
       command: "{{ gitlab_runner_executable }} stop"
 
-    - name: (MacOS) Download GitLab Runner
+    - name: (MacOS) 
+      become: true
       get_url:
         url: "{{ gitlab_runner_download_url }}"
         dest: "{{ gitlab_runner_executable }}"

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -915,7 +915,7 @@
   when: item|length
 
 - name: "{{ runn_name_prefix }} Ensure directory access test"
-  command: /usr/bin/test -r {{ item }}
+  command: test -r {{ item }}
   loop:
     - '{{ gitlab_runner.builds_dir | default("") }}'
     - '{{ gitlab_runner.cache_dir | default("") }}'


### PR DESCRIPTION
Hi @riemers,

I have been having issues using the current role on my OSX systems. There a two issues right now that prevent the role from succeeding.

- When re-running the role, the `(MacOS) INSTALL GitLab Runner for macOS` fails because it cannot override the existing executable, as it was downloaded with `become: yes`
- The `/usr/bin/test` command is not available on all hosts as it is a built-in command for some shells and therefore fails

