### PR TITLE
vars: unify and move gitlab_runner_timeout_stop_seconds to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,9 @@ gitlab_runner_container_network: default
 # default state to restart
 gitlab_runner_restart_state: restarted
 
+# systemd service kill timeout (time to wait for running jobs on stop)
+gitlab_runner_timeout_stop_seconds: 7200
+
 # default value for log_format
 # gitlab_runner_log_format: runner
 

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -5,4 +5,3 @@ gitlab_runner_executable: /usr/bin/{{ gitlab_runner_package_name }}
 gitlab_runner_runtime_owner: gitlab-runner
 gitlab_runner_runtime_group: gitlab-runner
 gitlab_runner_restart_state: reloaded
-gitlab_runner_timeout_stop_seconds: 720

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,4 +5,3 @@ gitlab_runner_executable: /usr/bin/{{ gitlab_runner_package_name }}
 gitlab_runner_runtime_owner: gitlab-runner
 gitlab_runner_runtime_group: gitlab-runner
 gitlab_runner_restart_state: reloaded
-gitlab_runner_timeout_stop_seconds: 720

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,4 +4,3 @@ gitlab_runner_executable: /usr/bin/{{ gitlab_runner_package_name }}
 
 gitlab_runner_runtime_owner: gitlab-runner
 gitlab_runner_runtime_group: gitlab-runner
-gitlab_runner_timeout_stop_seconds: 7200


### PR DESCRIPTION
There's not really a reason to have different values for each os. This unifies the default to be 7200 and allows overriding it (because it's now just a default var). I use the override for hosts with long running ci jobs.