### PR TITLE
fix: impossible to change debian package version which is on the apt hold list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This role will install the [official GitLab Runner](https://gitlab.com/gitlab-or
 Requirements
 ------------
 
-This role requires Ansible 2.7 or higher.
+This role requires Ansible 2.13 or higher.
 
 Role Variables
 --------------
@@ -174,3 +174,4 @@ Feel free to add your name to the readme if you make a PR. A full list of people
 - Matthias Schmieder for adding Windows Support
 - dniwdeus & rosenstrauch for adding AWS autoscale option
 - oscillate123 for fixing Windows config.toml idempotency
+- [cchaudier](https://github.com/cchaudier) for fixing changing the version of a package which is on the apt hold list

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   namespace: riemers
   description: GitLab Runner
   license: MIT
-  min_ansible_version: 2.7
+  min_ansible_version: 2.13
   platforms:
     - name: EL
       versions:

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -46,6 +46,7 @@
   apt:
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
+    allow_change_held_packages: true
     allow_downgrade: true
   become: true
   environment:
@@ -56,6 +57,7 @@
   apt:
     name: "{{ gitlab_runner_package }}"
     state: "{{ gitlab_runner_package_state }}"
+    allow_change_held_packages: true
     allow_downgrade: true
   become: true
   when: ansible_distribution_release not in ["buster", "focal", "jammy"]


### PR DESCRIPTION
- `allow_downgrade` has been added in ansible-core 2.12
- `allow_change_held_packages` has been added in ansible-core 2.13
- Fix issue #327