### PR TITLE
add support for 'gitlab-runner register --docker-allowed-pull-policies' 

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -65,6 +65,9 @@
       {% if gitlab_runner.docker_oom_kill_disable|default(false) %}
       --docker-oom-kill-disable '{{ gitlab_runner.docker_oom_kill_disable|default("false") }}'
       {% endif %}
+      {% for policy in gitlab_runner.docker_allowed_pull_policies|default([]) %}
+      --docker-allowed-pull-policies "{{ policy }}"
+      {% endfor %}
       {% for policy in gitlab_runner.docker_pull_policy|default([]) %}
       --docker-pull-policy "{{ policy }}"
       {% endfor %}

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -327,6 +327,20 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
+- name: "{{ runn_name_prefix }} Set docker allowed_pull_policies option"
+  lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: ^\s*allowed_pull_policies =
+    line: "    allowed_pull_policies = {{ gitlab_runner.docker_allowed_pull_policies|default([])|to_json }}"
+    state: "{{ 'present' if gitlab_runner.docker_allowed_pull_policies is defined else 'absent' }}"
+    insertafter: ^\s*\[runners\.docker\]
+    backrefs: false
+  check_mode: false
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
+
 - name: "{{ runn_name_prefix }} Set docker volumes option"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"


### PR DESCRIPTION
Adds support for ```--docker-allowed-pull-policies``` when registering the runner, as documented here: https://docs.gitlab.com/runner/executors/docker.html#allow-docker-pull-policies