### PR TITLE
add config section feature_flags

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -248,6 +248,13 @@ gitlab_runner_runners:
     # Cache directory
     # cache_dir: '/cache'
     #
+    # Feature Flags
+    # See https://docs.gitlab.com/runner/configuration/feature-flags.html#available-feature-flags
+    #
+    # Sets feature flags. The default is not set.
+    # feature_flags:
+    #   - FF_TIMESTAMPS
+    #
     # Extra registration option
     # extra_registration_option: '--maximum-timeout=3600'
     #

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -885,20 +885,34 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
+#### [runners.feature_flags] section #####
+- name: "{{ runn_name_prefix }} Set feature flag options"
+  blockinfile:
+    path: "{{ temp_runner_config.path }}"
+    content: "{{ lookup('template', 'config.runners.feature_flags.j2') if gitlab_runner.feature_flags is defined }}"
+    state: "{{ 'present' if gitlab_runner.feature_flags is defined else 'absent' }}"
+    marker: "# {mark} runners.feature_flags"
+    insertafter: EOF
+  check_mode: false
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
+
 #### [runners.machine] section ####
 - name:  "{{ runn_name_prefix }} Set machine section"
   lineinfile:
     dest: "{{ temp_runner_config.path }}"
     regexp: '^\s*\[runners\.machine\]'
     line: '  [runners.machine]'
-    state: present
+    state: "{{ 'present' if gitlab_runner.machine_MachineOptions is defined else 'absent' }}"
     insertafter: EOF
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
-  - restart_gitlab_runner
-  - restart_gitlab_runner_macos
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
 
 - name:  "{{ runn_name_prefix }} Set machine MaxGrowthRate"
   lineinfile:
@@ -907,12 +921,12 @@
     line: '    MaxGrowthRate = {{ gitlab_runner.machine_MaxGrowthRate|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_MaxGrowthRate is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
-  - restart_gitlab_runner
-  - restart_gitlab_runner_macos
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
 
 - name:  "{{ runn_name_prefix }} Set machine IdleCount"
   lineinfile:
@@ -921,12 +935,12 @@
     line: '    IdleCount = {{ gitlab_runner.machine_IdleCount|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_IdleCount is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
-  - restart_gitlab_runner
-  - restart_gitlab_runner_macos
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
 
 - name: "{{ runn_name_prefix }} Set machine IdleScaleFactor"
   lineinfile:
@@ -935,8 +949,8 @@
     line: '    IdleScaleFactor = {{ gitlab_runner.machine_IdleScaleFactor|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_IdleScaleFactor is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
@@ -949,8 +963,8 @@
     line: '    IdleCountMin = {{ gitlab_runner.machine_IdleCountMin|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_IdleCountMin is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
@@ -963,8 +977,8 @@
     line: '    IdleTime = {{ gitlab_runner.machine_IdleTime|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_IdleTime is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
@@ -977,8 +991,8 @@
     line: '    MaxBuilds = {{ gitlab_runner.machine_MaxBuilds|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_MaxBuilds is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
@@ -991,8 +1005,8 @@
     line: '    MachineName = {{ gitlab_runner.machine_MachineName|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_MachineName is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
@@ -1005,8 +1019,8 @@
     line: '    MachineDriver = {{ gitlab_runner.machine_MachineDriver|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_MachineDriver is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
@@ -1019,8 +1033,8 @@
     line: '    MachineOptions = {{ gitlab_runner.machine_MachineOptions|default("") | to_json }}'
     state: "{{ 'present' if gitlab_runner.machine_MachineOptions is defined else 'absent' }}"
     insertafter: '^\s*\[runners\.machine\]'
-    backrefs: no
-  check_mode: no
+    backrefs: false
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
     - restart_gitlab_runner
@@ -1035,11 +1049,11 @@
     state: "{{ 'present' if gitlab_runner.machine_autoscaling is defined else 'absent' }}"
     marker: "# {mark} runners.machine.autoscaling"
     insertafter: EOF
-  check_mode: no
+  check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
   notify:
-  - restart_gitlab_runner
-  - restart_gitlab_runner_macos
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
 
 - name: "{{ runn_name_prefix }} Set builds dir file option"
   lineinfile:

--- a/templates/config.runners.feature_flags.j2
+++ b/templates/config.runners.feature_flags.j2
@@ -1,0 +1,4 @@
+  [runners.feature_flags]
+{% for flag in gitlab_runner.feature_flags %}
+    {{ flag }} = true
+{% endfor %}


### PR DESCRIPTION
I couldn't configure runners.feature_flags, so I added support for feature flags which are described here: 
https://docs.gitlab.com/runner/configuration/feature-flags.html#available-feature-flags

Other fixes:
* fixed some linting and bool values for consistency
* only add machine section if machine_MachineOptions is set

If I should split this PR into separate ones, please let me know.