### PR TITLE
Add runner registration with runner auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ On Linux, use `gitlab_runner_package_version` instead.
 - `gitlab_runner_concurrent` - The maximum number of global jobs to run concurrently. Defaults to the number of processor cores.
 - `gitlab_runner_registration_token` - The GitLab registration token. If this is specified, each runner will be registered to a GitLab server. Deprecating in gitlab version 16.0 and removed in 18.0.
 - `gitlab_runner_registration_token_type` - Gitlab runner registration token type
-Set "runner-token" to register runner with --token option (new workflow https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html)
+Set "authentication-token" to register runner with --token option (new workflow https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html)
 Set "registration-token" to register runner with --registration-token option (deprecating in gitlab 16.0 but still usable and deleted in 18.0)
-For gitlab version >= 16.0 it is advisable to specify token for each runner in 'gitlab_runner_runners' section and set this variable to "runner-token".
+For gitlab version >= 16.0 it is advisable to specify token for each runner in 'gitlab_runner_runners' section and set this variable to "authentication-token".
 - `gitlab_runner_coordinator_url` - The GitLab coordinator URL. Defaults to `https://gitlab.com`.
 - `gitlab_runner_sentry_dsn` - Enable tracking of all system level errors to Sentry
 - `gitlab_runner_listen_address` - Enable `/metrics` endpoint for Prometheus scraping.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ Role Variables
 On Mac OSX and Windows, use e.g. `gitlab_runner_wanted_version: 12.4.1`.
 On Linux, use `gitlab_runner_package_version` instead.
 - `gitlab_runner_concurrent` - The maximum number of global jobs to run concurrently. Defaults to the number of processor cores.
-- `gitlab_runner_registration_token` - The GitLab registration token. If this is specified, a runner will be registered to a GitLab server.
+- `gitlab_runner_registration_token` - The GitLab registration token. If this is specified, each runner will be registered to a GitLab server. Deprecating in gitlab version 16.0 and removed in 18.0.
+- `gitlab_runner_registration_token_type` - Gitlab runner registration token type
+Set "runner-token" to register runner with --token option (new workflow https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html)
+Set "registration-token" to register runner with --registration-token option (deprecating in gitlab 16.0 but still usable and deleted in 18.0)
+For gitlab version >= 16.0 it is advisable to specify token for each runner in 'gitlab_runner_runners' section and set this variable to "runner-token".
 - `gitlab_runner_coordinator_url` - The GitLab coordinator URL. Defaults to `https://gitlab.com`.
 - `gitlab_runner_sentry_dsn` - Enable tracking of all system level errors to Sentry
 - `gitlab_runner_listen_address` - Enable `/metrics` endpoint for Prometheus scraping.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,13 @@ gitlab_runner_coordinator_url: https://gitlab.com
 # GitLab registration token
 gitlab_runner_registration_token: ""
 
+# Gitlab runner registration token type:
+# "runner-token" - Register runner with --token option (new workflow https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html)
+# "registration-token" - Register runner with --registration-token option (deprecating in gitlab 16.0 but still usable and deleted in 18.0)
+# For gitlab version >= 16.0 it is advisable to specify token for each runner in 'gitlab_runner_runners' section
+# and set this variable to "runner-token"
+gitlab_runner_registration_token_type: "registration-token"
+
 gitlab_runner_sentry_dsn: ""
 
 # GitLab server IP
@@ -89,7 +96,7 @@ gitlab_runner_timeout_stop_seconds: 7200
 # gitlab_runner_log_format: runner
 
 # defines value for log_level
-# Defines the log level. Options are debug, info, warn, error, fatal, and panic. 
+# Defines the log level. Options are debug, info, warn, error, fatal, and panic.
 # This setting has lower priority than the level set by the command-line arguments --debug, -l, or --log-level.
 # gitlab_runner_log_level: "warning"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,10 +29,10 @@ gitlab_runner_coordinator_url: https://gitlab.com
 gitlab_runner_registration_token: ""
 
 # Gitlab runner registration token type:
-# "runner-token" - Register runner with --token option (new workflow https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html)
+# "authentication-token" - Register runner with --token option (new workflow https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html)
 # "registration-token" - Register runner with --registration-token option (deprecating in gitlab 16.0 but still usable and deleted in 18.0)
 # For gitlab version >= 16.0 it is advisable to specify token for each runner in 'gitlab_runner_runners' section
-# and set this variable to "runner-token"
+# and set this variable to "authentication-token"
 gitlab_runner_registration_token_type: "registration-token"
 
 gitlab_runner_sentry_dsn: ""

--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -3,7 +3,7 @@
   set_fact:
     register_runner_cmd: >-
       register
-      {% if gitlab_runner_registration_token_type != "runner-token" %}
+      {% if gitlab_runner_registration_token_type != "authentication-token" %}
       --locked='{{ gitlab_runner.locked|default(false) }}'
       --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
       {% if gitlab_runner.run_untagged|default(true) %}
@@ -115,7 +115,7 @@
       ansible.builtin.copy:
         content: >
           {{ register_runner_cmd }}
-          {% if gitlab_runner_registration_token_type == "runner-token" %}
+          {% if gitlab_runner_registration_token_type == "authentication-token" %}
           --token '{{ gitlab_runner.token|hash("sha1") }}'
           {% else %}
           --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
@@ -149,7 +149,7 @@
     image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
     command: >
       {{ register_runner_cmd }}
-      {% if gitlab_runner_registration_token_type == "runner-token" %}
+      {% if gitlab_runner_registration_token_type == "authentication-token" %}
       --token '{{ gitlab_runner.token }}'
       {% else %}
       --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'

--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -3,23 +3,25 @@
   set_fact:
     register_runner_cmd: >-
       register
-      --non-interactive
-      --url '{{ gitlab_runner.url | default(gitlab_runner_coordinator_url) }}'
-      --description '{{ actual_gitlab_runner_name }}'
+      {% if gitlab_runner_registration_token_type != "runner-token" %}
+      --locked='{{ gitlab_runner.locked|default(false) }}'
       --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
-      {% if gitlab_runner.clone_url|default(false) %}
-      --clone-url "{{ gitlab_runner.clone_url }}"
-      {% endif %}
       {% if gitlab_runner.run_untagged|default(true) %}
       --run-untagged
       {% endif %}
       {% if gitlab_runner.protected|default(false) %}
       --access-level="ref_protected"
       {% endif %}
+      {% endif %}
+      --non-interactive
+      --url '{{ gitlab_runner.url | default(gitlab_runner_coordinator_url) }}'
+      --description '{{ actual_gitlab_runner_name }}'
+      {% if gitlab_runner.clone_url|default(false) %}
+      --clone-url "{{ gitlab_runner.clone_url }}"
+      {% endif %}
       --executor '{{ gitlab_runner.executor|default("shell") }}'
       --limit '{{ gitlab_runner.concurrent_specific|default(0) }}'
       --output-limit '{{ gitlab_runner.output_limit|default(4096) }}'
-      --locked='{{ gitlab_runner.locked|default(false) }}'
       {% for env_var in gitlab_runner.env_vars|default([]) %}
       --env '{{ env_var }}'
       {% endfor %}
@@ -113,7 +115,11 @@
       ansible.builtin.copy:
         content: >
           {{ register_runner_cmd }}
+          {% if gitlab_runner_registration_token_type == "runner-token" %}
+          --token '{{ gitlab_runner.token|hash("sha1") }}'
+          {% else %}
           --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
+          {% endif %}
           {% if gitlab_runner.cache_s3_secret_key is defined %}
           --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key|hash("sha1") }}'
           {% endif %}
@@ -143,7 +149,11 @@
     image: "{{ gitlab_runner_container_image }}:{{ gitlab_runner_container_tag }}"
     command: >
       {{ register_runner_cmd }}
+      {% if gitlab_runner_registration_token_type == "runner-token" %}
+      --token '{{ gitlab_runner.token }}'
+      {% else %}
       --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
+      {% endif %}
       {% if gitlab_runner.cache_s3_secret_key is defined %}
       --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
       {% endif %}

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -3,7 +3,7 @@
   set_fact:
     register_runner_cmd: >-
       {{ gitlab_runner_executable }} register
-      {% if gitlab_runner_registration_token_type != "runner-token" %}
+      {% if gitlab_runner_registration_token_type != "authentication-token" %}
       --locked='{{ gitlab_runner.locked|default(false) }}'
       --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
       {% if gitlab_runner.run_untagged|default(true) %}
@@ -114,7 +114,7 @@
       ansible.builtin.copy:
         content: >-
           {{ register_runner_cmd }}
-          {% if gitlab_runner_registration_token_type == "runner-token" %}
+          {% if gitlab_runner_registration_token_type == "authentication-token" %}
           --token '{{ gitlab_runner.token|hash("sha1") }}'
           {% else %}
           --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
@@ -145,7 +145,7 @@
 - name: (Windows) Register runner to GitLab
   win_shell: >-
     {{ register_runner_cmd }}
-    {% if gitlab_runner_registration_token_type == "runner-token" %}
+    {% if gitlab_runner_registration_token_type == "authentication-token" %}
     --token '{{ gitlab_runner.token }}'
     {% else %}
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -3,18 +3,21 @@
   set_fact:
     register_runner_cmd: >-
       {{ gitlab_runner_executable }} register
-      --non-interactive
-      --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
-      --description '{{ actual_gitlab_runner_name }}'
+      {% if gitlab_runner_registration_token_type != "runner-token" %}
+      --locked='{{ gitlab_runner.locked|default(false) }}'
       --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
-      {% if gitlab_runner.clone_url|default(false) %}
-      --clone-url "{{ gitlab_runner.clone_url }}"
-      {% endif %}
       {% if gitlab_runner.run_untagged|default(true) %}
       --run-untagged
       {% endif %}
       {% if gitlab_runner.protected|default(false) %}
       --access-level="ref_protected"
+      {% endif %}
+      {% endif %}
+      --non-interactive
+      --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
+      --description '{{ actual_gitlab_runner_name }}'
+      {% if gitlab_runner.clone_url|default(false) %}
+      --clone-url "{{ gitlab_runner.clone_url }}"
       {% endif %}
       --executor '{{ gitlab_runner.executor|default("shell") }}'
       {% if gitlab_runner.shell is defined %}
@@ -22,7 +25,6 @@
       {% endif %}
       --limit '{{ gitlab_runner.concurrent_specific|default(0) }}'
       --output-limit '{{ gitlab_runner.output_limit|default(4096) }}'
-      --locked='{{ gitlab_runner.locked|default(false) }}'
       {% for env_var in gitlab_runner.env_vars|default([]) %}
       --env '{{ env_var }}'
       {% endfor %}
@@ -112,7 +114,11 @@
       ansible.builtin.copy:
         content: >-
           {{ register_runner_cmd }}
+          {% if gitlab_runner_registration_token_type == "runner-token" %}
+          --token '{{ gitlab_runner.token|hash("sha1") }}'
+          {% else %}
           --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
+          {% endif %}
           {% if gitlab_runner.cache_s3_secret_key is defined %}
           --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key|hash("sha1") }}'
           {% endif %}
@@ -139,7 +145,11 @@
 - name: (Windows) Register runner to GitLab
   win_shell: >-
     {{ register_runner_cmd }}
+    {% if gitlab_runner_registration_token_type == "runner-token" %}
+    --token '{{ gitlab_runner.token }}'
+    {% else %}
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
+    {% endif %}
     {% if gitlab_runner.cache_s3_secret_key is defined %}
     --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
     {% endif %}

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -11,7 +11,7 @@
   set_fact:
     register_runner_cmd: >-
       {{ gitlab_runner_executable }} register
-      {% if gitlab_runner_registration_token_type != "runner-token" %}
+      {% if gitlab_runner_registration_token_type != "authentication-token" %}
       --locked='{{ gitlab_runner.locked|default(false) }}'
       --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
       {% if gitlab_runner.run_untagged|default(true) %}
@@ -153,7 +153,7 @@
       ansible.builtin.copy:
         content: >
           {{ register_runner_cmd }}
-          {% if gitlab_runner_registration_token_type == "runner-token" %}
+          {% if gitlab_runner_registration_token_type == "authentication-token" %}
           --token '{{ gitlab_runner.token|hash("sha1") }}'
           {% else %}
           --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
@@ -184,7 +184,7 @@
 - name: Register runner to GitLab
   command: >
     {{ register_runner_cmd }}
-    {% if gitlab_runner_registration_token_type == "runner-token" %}
+    {% if gitlab_runner_registration_token_type == "authentication-token" %}
     --token '{{ gitlab_runner.token }}'
     {% else %}
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -11,18 +11,21 @@
   set_fact:
     register_runner_cmd: >-
       {{ gitlab_runner_executable }} register
-      --non-interactive
-      --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
-      --name '{{ actual_gitlab_runner_name }}'
+      {% if gitlab_runner_registration_token_type != "runner-token" %}
+      --locked='{{ gitlab_runner.locked|default(false) }}'
       --tag-list '{{ gitlab_runner.tags|default([]) | join(",") }}'
-      {% if gitlab_runner.clone_url|default(false) %}
-      --clone-url "{{ gitlab_runner.clone_url }}"
-      {% endif %}
       {% if gitlab_runner.run_untagged|default(true) %}
       --run-untagged
       {% endif %}
       {% if gitlab_runner.protected|default(false) %}
       --access-level="ref_protected"
+      {% endif %}
+      {% endif %}
+      --non-interactive
+      --url '{{ gitlab_runner.url|default(gitlab_runner_coordinator_url) }}'
+      --name '{{ actual_gitlab_runner_name }}'
+      {% if gitlab_runner.clone_url|default(false) %}
+      --clone-url "{{ gitlab_runner.clone_url }}"
       {% endif %}
       --executor '{{ gitlab_runner.executor|default("shell") }}'
       {% if gitlab_runner.shell is defined %}
@@ -30,7 +33,6 @@
       {% endif %}
       --limit '{{ gitlab_runner.concurrent_specific|default(0) }}'
       --output-limit '{{ gitlab_runner.output_limit|default(4096) }}'
-      --locked='{{ gitlab_runner.locked|default(false) }}'
       {% for env_var in gitlab_runner.env_vars|default([]) %}
       --env '{{ env_var }}'
       {% endfor %}
@@ -151,7 +153,11 @@
       ansible.builtin.copy:
         content: >
           {{ register_runner_cmd }}
+          {% if gitlab_runner_registration_token_type == "runner-token" %}
+          --token '{{ gitlab_runner.token|hash("sha1") }}'
+          {% else %}
           --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token)|hash("sha1") }}'
+          {% endif %}
           {% if gitlab_runner.cache_s3_secret_key is defined %}
           --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key|hash("sha1") }}'
           {% endif %}
@@ -178,7 +184,11 @@
 - name: Register runner to GitLab
   command: >
     {{ register_runner_cmd }}
+    {% if gitlab_runner_registration_token_type == "runner-token" %}
+    --token '{{ gitlab_runner.token }}'
+    {% else %}
     --registration-token '{{ gitlab_runner.token|default(gitlab_runner_registration_token) }}'
+    {% endif %}
     {% if gitlab_runner.cache_s3_secret_key is defined %}
     --cache-s3-secret-key '{{ gitlab_runner.cache_s3_secret_key }}'
     {% endif %}


### PR DESCRIPTION
To support "--token" option: runner register --token glrt-XXXXXXXX

New workflow https://docs.gitlab.com/ee/ci/runners/new_creation_workflow.html