### PR TITLE
Feature: Allow overwriting of 'gitlab_runner_install_directory'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,9 @@ gitlab_runner_wanted_version: latest
 # This variable should not be modified usually as it depends on the gitlab_runner_wanted_version variable
 gitlab_runner_wanted_tag: "{{ 'latest' if gitlab_runner_wanted_version == 'latest' else ('v' + gitlab_runner_wanted_version) }}"
 
-# If a different partition or disk is used under Windows
-gitlab_runner_install_directory: c:/gitlab-runner/
+# Override the install directory under Windows via host variables etc. (Default: c:/gitlab-runner)
+gitlab_runner_custom_install_directory: ""
+gitlab_runner_install_directory: "{{ gitlab_runner_default_install_directory if (gitlab_runner_custom_install_directory == '') else gitlab_runner_custom_install_directory }}"
 
 # Overridden based on platform
 gitlab_runner_config_file: "{{ __gitlab_runner_config_file_system_mode if gitlab_runner_system_mode else __gitlab_runner_config_file_user_mode }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ gitlab_runner_wanted_version: latest
 # This variable should not be modified usually as it depends on the gitlab_runner_wanted_version variable
 gitlab_runner_wanted_tag: "{{ 'latest' if gitlab_runner_wanted_version == 'latest' else ('v' + gitlab_runner_wanted_version) }}"
 
+# If a different partition or disk is used under Windows
+gitlab_runner_install_directory: c:/gitlab-runner/
+
 # Overridden based on platform
 gitlab_runner_config_file: "{{ __gitlab_runner_config_file_system_mode if gitlab_runner_system_mode else __gitlab_runner_config_file_user_mode }}"
 gitlab_runner_config_file_location: "{{ gitlab_runner_config_file | dirname }}"

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -2,7 +2,6 @@
 
 gitlab_runner_download_url: https://gitlab-runner-downloads.s3.amazonaws.com/{{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-windows-amd64.exe
 
-gitlab_runner_install_directory: c:/gitlab-runner/
 gitlab_runner_config_file_location: "{{ gitlab_runner_install_directory }}"
 gitlab_runner_config_file: "{{ gitlab_runner_config_file_location }}/config.toml" # on Windows
 

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -2,6 +2,10 @@
 
 gitlab_runner_download_url: https://gitlab-runner-downloads.s3.amazonaws.com/{{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-windows-amd64.exe
 
+# working directory for gitlab runner. defaults to config file directory
+gitlab_runner_working_directory: ""
+
+gitlab_runner_default_install_directory: c:/gitlab-runner/
 gitlab_runner_config_file_location: "{{ gitlab_runner_install_directory }}"
 gitlab_runner_config_file: "{{ gitlab_runner_config_file_location }}/config.toml" # on Windows
 


### PR DESCRIPTION
Under Windows, it is a common practice to use different partitions or hard disks to prevent applications from overloading the main hard disk and crashing the system. GitLab Runner is also a good candidate to fill up the disk and crash the computer. Therefore, it would be helpful to install it on a separate hard disk, but at the moment this is not possible due to variable precedence.

https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence

Therefore, the installation directory should be moved to the defaults and then this can be changed in the inventory for each host or globally.