### PR TITLE
Add `gitlab_runner_no_log_secrets` to list of configured runners

### DIFF
--- a/tasks/list-configured-runners-unix.yml
+++ b/tasks/list-configured-runners-unix.yml
@@ -17,6 +17,7 @@
     json_item: "{{ item | from_json }}"
   loop: "{{ registered_runners_json_result.stderr_lines }}"
   when: "'Executor' in json_item"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
 
 - name: Print registered runners
   debug: var=registered_gitlab_runner_names


### PR DESCRIPTION
When I used the role to deploy Gitlab runners with the new workflow (Gitlab runner version 17.2.1) I noticed that the step `Create list of configured runners` displayed the runner token despite the `gitlab_runner_no_log_secrets` option being set.

This PR adds the `no_log` option to this step to prevent the output of the runner token.

Example before patch:
```
TASK [riemers.gitlab-runner : Create list of configured runners] ***************************************************************************************
skipping: [terraform-ci] => (item={'arch': 'amd64', 'level': 'info', 'msg': 'Runtime platform', 'os': 'linux', 'pid': 15288, 'revision': '9882d9c7', 'time': '2024-08-02T08:56:14Z', 'version': '17.2.1'}) 
skipping: [terraform-ci] => (item={'ConfigFile': '/etc/gitlab-runner/config.toml', 'level': 'info', 'msg': 'Listing configured runners', 'time': '2024-08-02T08:56:14Z'}) 
ok: [terraform-ci] => (item={'Executor': 'docker', 'Token': 'glrt-NOTMYTOKEN', 'URL': 'https://xxx', 'level': 'info', 'msg': 'Terraform CI', 'time': '2024-08-02T08:56:14Z'})
```

Example after patch:
```
TASK [riemers.gitlab-runner : Create list of configured runners] ***************************************************************************************
skipping: [terraform-ci] => (item=None) 
skipping: [terraform-ci] => (item=None) 
ok: [terraform-ci] => (item=None)
```