### PR TITLE
ansible 2.16: add docker dependency

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,4 @@
+---
+profile: production
 warn_list:
-  - 'role-name'
+  - role-name  # until role name is fixed on galaxy https://github.com/riemers/ansible-gitlab-runner/pull/312

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+warn_list:
+  - 'role-name'

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See the [config for more options](https://github.com/riemers/ansible-gitlab-runn
 
 Example Playbook
 ----------------
+
 ```yaml
 - hosts: all
   become: true
@@ -92,6 +93,7 @@ Example Playbook
 ```
 
 Inside `vars/main.yml`
+
 ```yaml
 gitlab_runner_coordinator_url: https://gitlab.com
 gitlab_runner_registration_token: '12341234'
@@ -101,6 +103,7 @@ gitlab_runner_runners:
     token: 'abcd'
     # url is an optional override to the global gitlab_runner_coordinator_url
     url: 'https://my-own-gitlab.mydomain.com'
+    # each executor can have optional dependencies e.g: "docker" -> "community.docker"
     executor: docker
     docker_image: 'alpine'
     tags:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,3 +27,7 @@ galaxy_info:
     - ci
 
 dependencies: []
+  # optional dependency: docker-executor
+  # - community.docker
+  # optional dependency: windows host
+  # - ansible.windows

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,6 @@
 galaxy_info:
   author: Erik-jan Riemers
   namespace: riemers
-  role_name: gitlab-runner
   description: GitLab Runner
   license: MIT
   min_ansible_version: 2.13

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,7 @@
 galaxy_info:
   author: Erik-jan Riemers
   namespace: riemers
+  role_name: gitlab-runner
   description: GitLab Runner
   license: MIT
   min_ansible_version: 2.13


### PR DESCRIPTION
in ansible 2.16 the `docker_container` is no longer available. When installing the collection `community.docker` it works.