### PR TITLE
macos: remove duplicate `become`

### DIFF
--- a/tasks/install-macos.yml
+++ b/tasks/install-macos.yml
@@ -70,7 +70,6 @@
         url: "{{ gitlab_runner_download_url }}"
         dest: "{{ gitlab_runner_executable }}"
         force: true
-      become: true
 
     - name: (MacOS) Setting Permissions for gitlab-runner executable
       file:


### PR DESCRIPTION
already defined in line 68. and this can break interpreters for yaml...