### PR TITLE
Windows: Remove become to fix provisioning on Windows

### DIFF
--- a/tasks/global-setup-windows.yml
+++ b/tasks/global-setup-windows.yml
@@ -31,7 +31,6 @@
     insertafter: \s*concurrent.*
     state: present
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
-  become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_windows


### PR DESCRIPTION
This fixes a regression introduced in 62ec42ff causing the following error on Windows: "The powershell shell family is incompatible with the sudo become plugin".

See https://github.com/riemers/ansible-gitlab-runner/pull/315#issuecomment-2279144411 for background discussion.