### PR TITLE
Update main.yml to include the proper name

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,5 @@
 ---
 profile: production
 warn_list:
-  - role-name  # until role name is fixed on galaxy https://github.com/riemers/ansible-gitlab-runner/pull/312
+  # - role-name  # until role name is fixed on galaxy https://github.com/riemers/ansible-gitlab-runner/pull/312
   - no-changed-when  # TODO in future

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  role_name: gitlab-runner
   author: Erik-jan Riemers
   namespace: riemers
   description: GitLab Runner


### PR DESCRIPTION
It now auto releases an ansible-gitlab-runner which is not the main/name of the role. This should fix that and auto import it whenever a new release is created.