### PR TITLE
fix self-signed shell

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -1,9 +1,12 @@
 ---
 - name: Accept gitlab server self signed cert as valid CA
-  ansible.builtin.shell: |
+  ansible.builtin.shell: >
     set -o pipefail
+
     openssl s_client -connect {{ gitlab_server_ip }}:443 -showcerts </dev/null 2>/dev/null |
     sed -e '/-----BEGIN/,/-----END/!d' | tee {{ tls_ca_file }} >/dev/null
+  args:
+    executable: /usr/bin/bash
   when: force_accept_gitlab_server_self_signed
 
 - name: Update CA bundle with self signe cert of the gitlab server


### PR DESCRIPTION
sadly i have to report the current version throws:

```
"set -o pipefail\nopenssl s_client -connect some.company.portal.com:443 -showcerts </dev/null 2>/dev/null |\nsed -e '/-----BEGIN/,/-----END/!d' | tee /usr/local/share/ca-certificates/gitlabcert.crt >/dev/null\n"
```

I guess this fixes it (not tested yet)