### PR TITLE
Add ability to change runner working directory on mac and windows

### DIFF
--- a/tasks/install-macos.yml
+++ b/tasks/install-macos.yml
@@ -53,7 +53,11 @@
         mode: +x
 
     - name: (MacOS) Install GitLab Runner
-      ansible.builtin.command: "{{ gitlab_runner_executable }} install"
+      ansible.builtin.command: |
+        "{{ gitlab_runner_executable }} install"
+        {% if gitlab_runner_working_directory | default(false) %}
+        "--working-directory {{ gitlab_runner_working_directory }}"
+        {% endif %}
 
     - name: (MacOS) Start GitLab Runner
       ansible.builtin.command: "{{ gitlab_runner_executable }} start"

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -2,8 +2,14 @@
 
 gitlab_runner_arch: "{{ (ansible_machine == 'arm64') | ternary('arm64', 'amd64') }}"
 
+# it is not recommended to use system mode on macos
+gitlab_runner_system_mode: false
+
 gitlab_runner_download_url:
   "https://gitlab-runner-downloads.s3.amazonaws.com/{{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-darwin-{{ gitlab_runner_arch }}"
 
 gitlab_runner_directory: /usr/local/bin
 gitlab_runner_executable: "{{ gitlab_runner_directory }}/{{ gitlab_runner_package_name }}"
+
+# working directory for gitlab runner. defaults to current directory
+gitlab_runner_working_directory: ""

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -2,6 +2,9 @@
 
 gitlab_runner_download_url: https://gitlab-runner-downloads.s3.amazonaws.com/{{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-windows-amd64.exe
 
+# working directory for gitlab runner. defaults to config file directory
+gitlab_runner_working_directory: ""
+
 gitlab_runner_install_directory: c:/gitlab-runner/
 gitlab_runner_config_file_location: "{{ gitlab_runner_install_directory }}"
 gitlab_runner_config_file: "{{ gitlab_runner_config_file_location }}/config.toml"  # on Windows


### PR DESCRIPTION
I was running into an issue while using this project on macOS. The runner would put the build directory in my VM's shared directory, which is not what I wanted. I discovered that the gitlab-runner uses the current directory as the default when you install the runner — which is hard to control with Ansible. So, the easiest solution was the add the ability to control the working directory parameter via an Ansible fact.