### PR TITLE
Remove additional `docker-disable-cache` argument

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -58,9 +58,6 @@
       {% if gitlab_runner.docker_tlsverify | default(false) %}
       --docker-tlsverify '{{ gitlab_runner.docker_tlsverify | default("true") }}'
       {% endif %}
-      {% if gitlab_runner.docker_disable_cache | default(false) %}
-      --docker-disable-cache '{{ gitlab_runner.docker_disable_cache | default("false") }}'
-      {% endif %}
       {% if gitlab_runner.docker_dns | default(false) %}
       --docker-dns '{{ gitlab_runner.docker_dns | default("1.1.1.1") }}'
       {% endif %}


### PR DESCRIPTION
The command line argument for disabling the docker cache was passed twice, with the first one incorrectly adding `True` as a value to the argument. This commit removes the incorrect argument leaving only the valid one

Fixes #351 