### PR TITLE
Gitlab server cert fix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,8 @@ gitlab_runner_check_interval: 0
 
 # GitLab coordinator URL
 gitlab_runner_coordinator_url: https://gitlab.com
-# GitLab registration token
+
+# GitLab registration token.
 gitlab_runner_registration_token: ""
 
 # Gitlab runner registration token type:
@@ -43,9 +44,6 @@ gitlab_runner_registration_token: ""
 gitlab_runner_registration_token_type: "registration-token"
 
 gitlab_runner_sentry_dsn: ""
-
-# GitLab server IP
-gitlab_server_ip: ""
 
 # GitLab TLS CA file
 tls_ca_file: ""
@@ -124,6 +122,8 @@ gitlab_runner_runners:
     state: present
     # The executor used by the runner.
     executor: shell
+    # Set maximum build log size in kilobytes.
+    # token:
     # Set maximum build log size in kilobytes.
     output_limit: 4096
     # Maximum number of jobs to run concurrently on this specific runner.

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,3 +2,4 @@
 collections:
   - name: ansible.windows
   - name: community.docker
+  - name: community.crypto

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -1,13 +1,20 @@
 ---
 - name: Accept gitlab server self signed cert as valid CA
-  ansible.builtin.shell: >
-    set -o pipefail
-
-    openssl s_client -connect {{ gitlab_server_ip }}:443 -showcerts </dev/null 2>/dev/null |
-    sed -e '/-----BEGIN/,/-----END/!d' | tee {{ tls_ca_file }} >/dev/null
-  args:
-    executable: /usr/bin/bash
   when: force_accept_gitlab_server_self_signed
+  block:
+    - name: Grab the server cert for "{{ gitlab_runner_coordinator_url }}"
+      community.crypto.get_certificate:
+        host: "{{ gitlab_runner.url | default(gitlab_runner_coordinator_url) | regex_replace('https?:\/\/([^\/]+)\/?.*', '\\1') }}"
+        port: 443
+        asn1_base64: true # need to hard code to prevent depreciation warning
+      register: gitlab_server_cert
+    - name: Save the GitLab server self signed cert to the default CA path
+      ansible.builtin.copy:
+        content: "{{ gitlab_server_cert.cert }}"
+        dest: "{{ tls_ca_file }}"
+        mode: '0644'
+    - name: Update CA bundle with self signe cert of the gitlab server
+      ansible.builtin.import_tasks: update-ca-bundle.yml
 
 - name: Update CA bundle with self signe cert of the gitlab server
   ansible.builtin.import_tasks: update-ca-bundle.yml

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -5,3 +5,5 @@ gitlab_runner_executable: /usr/bin/{{ gitlab_runner_package_name }}
 gitlab_runner_runtime_owner: gitlab-runner
 gitlab_runner_runtime_group: gitlab-runner
 gitlab_runner_restart_state: reloaded
+
+tls_ca_file: /etc/ca-certificates/trust-source/anchors/gitlab-server.crt

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,3 +5,5 @@ gitlab_runner_executable: /usr/bin/{{ gitlab_runner_package_name }}
 gitlab_runner_runtime_owner: gitlab-runner
 gitlab_runner_runtime_group: gitlab-runner
 gitlab_runner_restart_state: reloaded
+
+tls_ca_file: /usr/share/ca-certificates/gitlab-server.crt

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,3 +4,5 @@ gitlab_runner_executable: /usr/bin/{{ gitlab_runner_package_name }}
 
 gitlab_runner_runtime_owner: gitlab-runner
 gitlab_runner_runtime_group: gitlab-runner
+
+tls_ca_file: /etc/pki/ca-trust/source/anchors/gitlab-server.crt


### PR DESCRIPTION
Using the gitlab url rather than the ip as the gitlab server may have multiple virtual hosts for registry or pages or mattermost running and would have separate certs.