### PR TITLE
fix: install gitlab-runner-helper-packages if version is specified

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # for versions >= 10.x
 gitlab_runner_package_name: gitlab-runner
+gitlab_runner_helper_package_name: gitlab-runner-helper-images
 
 gitlab_runner_system_mode: true
 

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -49,18 +49,6 @@
     allow_change_held_packages: true
     allow_downgrade: true
   become: true
-  environment:
-    GITLAB_RUNNER_DISABLE_SKEL: "true"
-  when: ansible_distribution_release in ["buster", "focal", "jammy"]
-
-- name: (Debian) Install GitLab Runner
-  ansible.builtin.apt:
-    name: "{{ gitlab_runner_package }}"
-    state: "{{ gitlab_runner_package_state }}"
-    allow_change_held_packages: true
-    allow_downgrade: true
-  become: true
-  when: ansible_distribution_release not in ["buster", "focal", "jammy"]
 
 - name: (Debian) Hold GitLab Runner version
   ansible.builtin.dpkg_selections:

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -19,9 +19,10 @@
   become: true
   when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 
-- name: (Debian) Update gitlab_runner_package_name
+- name: (Debian) Update gitlab_runner_package_name and gitlab_runner_helper_package_name
   ansible.builtin.set_fact:
     gitlab_runner_package: "{{ gitlab_runner_package_name }}={{ gitlab_runner_package_version }}"
+    gitlab_runner_helper_package: "{{ gitlab_runner_helper_package_name }}={{ gitlab_runner_package_version }}"
     gitlab_runner_package_state: present
   when: gitlab_runner_package_version is defined
 
@@ -42,6 +43,22 @@
     selection: install
   when: "'gitlab-runner' in ansible_facts.packages"
 
+- name: (Debian) Unhold GitLab Runner Helper version
+  changed_when: false
+  ansible.builtin.dpkg_selections:
+    name: "{{ gitlab_runner_helper_package_name }}"
+    selection: install
+  when: "'gitlab-runner-helper-images' in ansible_facts.packages"
+
+- name: (Debian) Install GitLab Runner Helpers
+  ansible.builtin.apt:
+    name: "{{ gitlab_runner_helper_package }}"
+    state: "{{ gitlab_runner_package_state }}"
+    allow_change_held_packages: true
+    allow_downgrade: true
+  become: true
+  when: gitlab_runner_package_version is defined
+
 - name: (Debian) Install GitLab Runner
   ansible.builtin.apt:
     name: "{{ gitlab_runner_package }}"
@@ -53,6 +70,13 @@
 - name: (Debian) Hold GitLab Runner version
   ansible.builtin.dpkg_selections:
     name: "{{ gitlab_runner_package_name }}"
+    selection: hold
+  when: gitlab_runner_package_version is defined
+  changed_when: false
+
+- name: (Debian) Hold GitLab Runner Helpers version
+  ansible.builtin.dpkg_selections:
+    name: "{{ gitlab_runner_helper_package_name }}"
     selection: hold
   when: gitlab_runner_package_version is defined
   changed_when: false


### PR DESCRIPTION
## Description

As of gitlab-runner version v17.7.1, when you install a specific version of gitlab-runner that is not the latest version, you must explicitly install the required gitlab-runner-helper-packages for that version. This requirement exists due to an apt/apt-get limitation.

## Current Behavior

The playbooks fail, as the required dependency is not met and apt can't resolve it automatically.

```
TASK [riemers.ansible-gitlab-runner : (Debian) Install GitLab Runner] **************************************************************************************************************************************
task path: /workspaces/Development/IaC/Ansible/Roles/riemers.ansible-gitlab-runner/tasks/install-debian.yml:45
fatal: [dettlx712.intra.ifm]: FAILED! => {"cache_update_time": 1738662513, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"       install 'gitlab-runner=17.7.1-1' --allow-downgrades --allow-change-held-packages' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n gitlab-runner : Depends: gitlab-runner-helper-images (= 17.7.1-1) but 17.8.3-1 is to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " gitlab-runner : Depends: gitlab-runner-helper-images (= 17.7.1-1) but 17.8.3-1 is to be installed"]}
```

## Related Issue

- https://gitlab.com/gitlab-org/gitlab-runner/-/commit/d3c664384efd1383cb9e323459c68244d9baa7fd
- https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/2942