### PR TITLE
Runner not created when docker_tlsverify: true under gitlab_runner_runners

### DIFF
--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -29,8 +29,8 @@
       {% if gitlab_runner.docker_privileged | default(false) %}
       --docker-privileged
       {% endif %}
-      {% if gitlab_runner.docker_tlsverify | default(false) %}
-      --docker-tlsverify '{{ gitlab_runner.docker_tlsverify | default("true") }}'
+      {% if gitlab_runner.docker_tlsverify is defined and gitlab_runner.docker_tlsverify %}
+      --docker-tlsverify
       {% endif %}
       {% if gitlab_runner.docker_dns | default(false) %}
       --docker-dns '{{ gitlab_runner.docker_dns | default("1.1.1.1") }}'

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -62,8 +62,8 @@
       {% if gitlab_runner.docker_wait_for_services_timeout | default(false) %}
       --docker-wait-for-services-timeout '{{ gitlab_runner.docker_wait_for_services_timeout | default(30) }}'
       {% endif %}
-      {% if gitlab_runner.docker_tlsverify | default(false) %}
-      --docker-tlsverify '{{ gitlab_runner.docker_tlsverify | default("true") }}'
+      {% if gitlab_runner.docker_tlsverify is defined and gitlab_runner.docker_tlsverify %}
+      --docker-tlsverify
       {% endif %}
       {% if gitlab_runner.docker_dns | default(false) %}
       --docker-dns '{{ gitlab_runner.docker_dns | default("1.1.1.1") }}'


### PR DESCRIPTION
When using a config like:

 ```
gitlab_runner_runners:
      - name: "Central-Debug-1"
        executor: docker
        state: present
        docker_image: 'docker:stable'
        docker_tlsverify: true
```

in `gitlab_runner_config_update_mode: by_registering`

the registration will fail, as the runner command is constructed with the parameter `--docker-tlsverify: True` instead of `--docker-tlsverify
`



Fixes https://github.com/riemers/ansible-gitlab-runner/issues/365
