### PR TITLE
Be able to published ports when gitlab-runner is deployed as a container

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,6 +92,9 @@ gitlab_runner_container_latest_update: false
 # this option uses network_mode, thus 'default' will use the first network found in docker network list
 gitlab_runner_container_network: default
 
+# List of ports to publish from the container to the host.
+gitlab_runner_container_published_ports: ""
+
 # default state to restart
 gitlab_runner_restart_state: restarted
 

--- a/tasks/main-container.yml
+++ b/tasks/main-container.yml
@@ -57,3 +57,4 @@
         source: /var/run/docker.sock
         target: /var/run/docker.sock
     network_mode: "{{ gitlab_runner_container_network }}"
+    published_ports: "{{ gitlab_runner_container_published_ports }}"


### PR DESCRIPTION
With a config like 

```
        gitlab_runner_container_install: true
        gitlab_runner_config_update_mode: by_registering
        gitlab_unregister_runner_executors_which_are_not_longer_configured: true
        gitlab_runner_listen_address: ":9252"
        gitlab_runner_container_image: "gitlab/gitlab-runner"
        gitlab_runner_container_name: "gitlab-runner"
        gitlab_runner_container_tag: "ubuntu-v17.8.3"
        gitlab_runner_container_mount_path: "/etc/gitlab-runner"

```
 where the metrics are generated on port 9252 and gitlab-runner is deployed as a container, we must be able to map the port to the host.

I propose to add a new variable:
`gitlab_runner_container_published_ports`
where we can list the published ports of the container.

For example
 ` gitlab_runner_container_published_ports: "9252:9252"`

 