### PR TITLE
Add possibility to setup disable_strict_host_key_checking [runners.ssh] in registering mode

### DIFF
--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -57,6 +57,7 @@
       --ssh-host '{{ gitlab_runner.ssh_host | default("") }}'
       --ssh-port '{{ gitlab_runner.ssh_port | default("") }}'
       --ssh-identity-file '{{ gitlab_runner.ssh_identity_file | default("") }}'
+      --ssh-disable-strict-host-key-checking '{{ gitlab_runner.ssh_disable_strict_host_key_checking | default("false") }}'
       {% if gitlab_runner.cache_type is defined %}
       --cache-type '{{ gitlab_runner.cache_type }}'
       {% endif %}

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -56,6 +56,9 @@
       {% if gitlab_runner.ssh_identity_file is defined %}
       --ssh-identity-file '{{ gitlab_runner.ssh_identity_file }}'
       {% endif %}
+      {%if gitlab_runner.ssh_disable_strict_host_key_checking is defined %}
+      --ssh-disable-strict-host-key-checking '{{ gitlab_runner.ssh_disable_strict_host_key_checking }}'
+      {% endif %}
       {% if gitlab_runner.cache_type is defined %}
       --cache-type '{{ gitlab_runner.cache_type }}'
       {% endif %}

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -96,6 +96,7 @@
       --ssh-host '{{ gitlab_runner.ssh_host | default("") }}'
       --ssh-port '{{ gitlab_runner.ssh_port | default("") }}'
       --ssh-identity-file '{{ gitlab_runner.ssh_identity_file | default("") }}'
+      --ssh-disable-strict-host-key-checking '{{ gitlab_runner.ssh_disable_strict_host_key_checking | default("false") }}'
       {% if gitlab_runner.executor == "virtualbox" and gitlab_runner.virtualbox_base_name %}
           --virtualbox-base-name '{{ gitlab_runner.virtualbox_base_name }}'
           --virtualbox-base-snapshot '{{ gitlab_runner.virtualbox_base_snapshot | default("") }}'


### PR DESCRIPTION
When setting up an ssh runner, using `gitlab_runner_config_update_mode: by_registering`, we cannot set the `disable_strict_host_key_checking`.

This PR adds the possibility of setting it:
 ```
gitlab_runner_runners:
      - name: "test4"
        token: "my token"
        url: "https://gitlab.mycompany.com/"
        executor: ssh
        ssh_user: "mysshuser"
        ssh_host: "mysshhost.mycompany.com"
        ssh_disable_strict_host_key_checking: true
```
