### PR TITLE
feat: add possiblity to bypass directory verifications

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -112,6 +112,9 @@ force_accept_gitlab_server_self_signed: false
 # controls diffs for assemble config file
 gitlab_runner_show_config_diff: false
 
+# controls whether the role verifies permissions and access on the builds_dir and cache_dir (Unix support only)
+gitlab_runner_verify_directories: true
+
 # controls logs on ansible configuration tasks, uncomment to prevent secret leaks (Unix support only).
 # gitlab_runner_no_log_secrets: yes
 

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -1096,14 +1096,14 @@
   loop:
     - '{{ gitlab_runner.builds_dir | default("") }}'
     - '{{ gitlab_runner.cache_dir | default("") }}'
-  when: item|length
+  when: item|length and gitlab_runner_verify_directories
 
 - name: "Ensure directory access test {{ runn_name_prefix }}"
   ansible.builtin.command: test -r {{ item }}
   loop:
     - '{{ gitlab_runner.builds_dir | default("") }}'
     - '{{ gitlab_runner.cache_dir | default("") }}'
-  when: item|length
+  when: item|length and gitlab_runner_verify_directories
   changed_when: false
   become: true
   become_user: "{{ gitlab_runner_runtime_owner | default(omit) }}"


### PR DESCRIPTION
In my case my runners are mounting a folder from an internal NAS as their cache folder.

This is working without problems but the role is verifying some permissions and access on this folder that are failing in my case.

I just wanted to add the possiblity to  disable these verifications if not needed by creating a new variable in the default : 

`# controls whether the role verifies permissions and access on the builds_dir and cache_dir (Unix support only)
gitlab_runner_verify_directories: true`