### PR TITLE
fix: install gitlab runner helpers only for version >= 17.7.0

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -48,7 +48,7 @@
   ansible.builtin.dpkg_selections:
     name: "{{ gitlab_runner_helper_package_name }}"
     selection: install
-  when: "'gitlab-runner-helper-images' in ansible_facts.packages"
+  when: ('gitlab-runner-helper-images' in ansible_facts.packages) and gitlab_runner_package_version is version('17.7.0', '>=')
 
 - name: (Debian) Install GitLab Runner Helpers
   ansible.builtin.apt:
@@ -57,7 +57,7 @@
     allow_change_held_packages: true
     allow_downgrade: true
   become: true
-  when: gitlab_runner_package_version is defined
+  when: gitlab_runner_package_version is defined and gitlab_runner_package_version is version('17.7.0', '>=')
 
 - name: (Debian) Install GitLab Runner
   ansible.builtin.apt:
@@ -78,7 +78,7 @@
   ansible.builtin.dpkg_selections:
     name: "{{ gitlab_runner_helper_package_name }}"
     selection: hold
-  when: gitlab_runner_package_version is defined
+  when: gitlab_runner_package_version is defined and gitlab_runner_package_version is version('17.7.0', '>=')
   changed_when: false
 
 - name: (Debian) Remove ~/gitlab-runner/.bash_logout on debian buster and ubuntu focal


### PR DESCRIPTION
Fix for https://github.com/riemers/ansible-gitlab-runner/pull/363#issuecomment-2683541935. Tested with gitlab-runner version 17.6.1 and 17.7.0.