### PR TITLE
feat: add fleeting autoscale support closes #372

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -1040,6 +1040,21 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
+#### [runners.autoscaler] section ####
+
+- name: "Set autoscaler section {{ runn_name_prefix }}"
+  ansible.builtin.blockinfile:
+    dest: "{{ temp_runner_config.path }}"
+    content: "{{ lookup('template', 'config.runners.autoscaler/autoscaler.j2') if gitlab_runner.autoscaler is defined }}"
+    state: "{{ 'present' if gitlab_runner.autoscaler is defined else 'absent' }}"
+    marker: "# {mark} runners.autoscaler"
+    insertafter: EOF
+  check_mode: false
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
+
 #### [[runners.machine.autoscaling]] section ####
 
 - name: "Set additional autoscaling option {{ runn_name_prefix }}"

--- a/templates/config.runners.autoscaler/autoscaler.j2
+++ b/templates/config.runners.autoscaler/autoscaler.j2
@@ -1,0 +1,19 @@
+  [runners.autoscaler]
+    plugin = "{{ gitlab_runner.autoscaler.plugin }}" # for >= 16.11, ensure you run `gitlab-runner fleeting install` to automatically install the plugin
+    capacity_per_instance = {{ gitlab_runner.autoscaler.capacity_per_instance }}
+    max_use_count = {{ gitlab_runner.autoscaler.max_use_count }}
+    max_instances = {{ gitlab_runner.autoscaler.max_instances }}
+
+    {{ lookup('template', 'config.runners.autoscaler/fleeting.plugin.' ~ gitlab_runner.autoscaler.plugin ~ '.j2') }}
+
+    [runners.autoscaler.connector_config]
+    {% for key, value in gitlab_runner.autoscaler.connector_config.items() %}
+      {{ key }} = {{ '"' ~ value ~ '"' if value is string else value | lower if value is boolean else value }}
+    {% endfor %}
+
+{% for policy in gitlab_runner.autoscaler.policies %}
+    [[runners.autoscaler.policy]]
+    {% for key, value in policy.items() %}
+      {{ key }} = {{ '"' ~ value ~ '"' if value is string else value | lower if value is boolean else value }}
+    {% endfor %}
+{% endfor %}

--- a/templates/config.runners.autoscaler/fleeting.plugin.aws.j2
+++ b/templates/config.runners.autoscaler/fleeting.plugin.aws.j2
@@ -1,0 +1,13 @@
+[runners.autoscaler.plugin_config]
+{% if gitlab_runner.autoscaler.plugin_config.name is defined %}
+  name = "{{ gitlab_runner.autoscaler.plugin_config.name }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.profile is defined %}
+  profile = "{{ gitlab_runner.autoscaler.plugin_config.profile }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.config_file is defined %}
+  config_file = "{{ gitlab_runner.autoscaler.plugin_config.config_file }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.credentials_file is defined %}
+  credentials_file = "{{ gitlab_runner.autoscaler.plugin_config.credentials_file }}"
+{% endif %}

--- a/templates/config.runners.autoscaler/fleeting.plugin.azure.j2
+++ b/templates/config.runners.autoscaler/fleeting.plugin.azure.j2
@@ -1,0 +1,10 @@
+[runners.autoscaler.plugin_config]
+{% if gitlab_runner.autoscaler.plugin_config.name is defined %}
+  name = "{{ gitlab_runner.autoscaler.plugin_config.name }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.subscription_id is defined %}
+  subscription_id = "{{ gitlab_runner.autoscaler.plugin_config.subscription_id }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.resource_group_name is defined %}
+  resource_group_name = "{{ gitlab_runner.autoscaler.plugin_config.resource_group_name }}"
+{% endif %}

--- a/templates/config.runners.autoscaler/fleeting.plugin.googlecloud.j2
+++ b/templates/config.runners.autoscaler/fleeting.plugin.googlecloud.j2
@@ -1,0 +1,16 @@
+[runners.autoscaler.plugin_config]
+{% if gitlab_runner.autoscaler.plugin_config.name is defined %}
+  name = "{{ gitlab_runner.autoscaler.plugin_config.name }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.project is defined %}
+  project = "{{ gitlab_runner.autoscaler.plugin_config.project }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.zone is defined %}
+  zone = "{{ gitlab_runner.autoscaler.plugin_config.zone }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.credentials_file is defined %}
+  credentials_file = "{{ gitlab_runner.autoscaler.plugin_config.credentials_file }}"
+{% endif %}
+{% if gitlab_runner.autoscaler.plugin_config.endpoint is defined %}
+  endpoint = "{{ gitlab_runner.autoscaler.plugin_config.endpoint }}"
+{% endif %}


### PR DESCRIPTION
This PR introduces support for GitLab runners utilizing [fleeting-based autoscaling](https://docs.gitlab.com/runner/fleet_scaling/fleeting/). It enables autoscaling configurations for [AWS](https://gitlab.com/gitlab-org/fleeting/plugins/aws), [GCP](https://gitlab.com/gitlab-org/fleeting/plugins/googlecloud), or [Azure ](https://gitlab.com/gitlab-org/fleeting/plugins/azure)fleeting plugins.

**New Feature**
The following YAML input is now supported for configuring autoscaling:

```yml
gitlab_runner_runners:
  - name: "runner-name" 
    token: "runner-token" 
    executor: "docker-autoscaler"
    docker_image: "alpine"

    autoscaler:
      plugin: "azure"
      capacity_per_instance: 1
      max_use_count: 1
      max_instances: 10

      plugin_config:
        name: "scaleset-name" 
        subscription_id: "subs-id" 
        resource_group_name: "rg-name" 

      connector_config:
        username: "azureuser"
        use_static_credentials: true
        timeout: "10m"
        use_external_addr: true

      policies:
        - idle_count: 5
          idle_time: "20m0s"
```

closes #372 
