### PR TITLE
fix: make sure helper package is set

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -49,7 +49,7 @@
   ansible.builtin.dpkg_selections:
     name: "{{ gitlab_runner_helper_package_name }}"
     selection: install
-  when: 
+  when:
     - ('gitlab-runner-helper-images' in ansible_facts.packages)
     - (gitlab_runner_package_version is undefined or gitlab_runner_package_version is version('17.7.0', '>='))
 

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -29,6 +29,7 @@
 - name: (Debian) Set gitlab_runner_package_name
   ansible.builtin.set_fact:
     gitlab_runner_package: "{{ gitlab_runner_package_name }}"
+    gitlab_runner_helper_package: "{{ gitlab_runner_helper_package_name }}"
     gitlab_runner_package_state: latest
   when: gitlab_runner_package_version is not defined
 


### PR DESCRIPTION
Ensure `gitlab_runner_helper_package` is Always Defined
Previously, the task "_(Debian) Install GitLab Runner Helpers_" failed due to `gitlab_runner_helper_package` being undefined.

This issue was introduced by a prior change that unintentionally tried to install gitlab_runner_helper_package_name even when it´s not set.

This PR ensures that `gitlab_runner_helper_package` is always defined, regardless of whether g`itlab_runner_package_version` is set.

closes: #375