### PR TITLE
Made published_ports for docker optional

### DIFF
--- a/tasks/main-container.yml
+++ b/tasks/main-container.yml
@@ -57,4 +57,4 @@
         source: /var/run/docker.sock
         target: /var/run/docker.sock
     network_mode: "{{ gitlab_runner_container_network }}"
-    published_ports: "{{ gitlab_runner_container_published_ports }}"
+    published_ports: "{{ gitlab_runner_container_published_ports | default(omit) }}"


### PR DESCRIPTION
In our environment we exclusively use docker to run our runners (heh).

Right now, the published_ports variable is mandatory. We do not want to publish any ports, so we didn't define it. 

This leads to the following: 

![image](https://github.com/user-attachments/assets/9e7c4175-d893-4a08-88df-004ac9ca39a4)

This PR fixes that :)