### PR TITLE
Make published_ports default var a list, as needed in docker module

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,7 +93,7 @@ gitlab_runner_container_latest_update: false
 gitlab_runner_container_network: default
 
 # List of ports to publish from the container to the host.
-gitlab_runner_container_published_ports: ""
+gitlab_runner_container_published_ports: []
 
 # default state to restart
 gitlab_runner_restart_state: restarted


### PR DESCRIPTION
This PR makes the published_ports default var a list, instead of a string. `default(omit)` didn't fully fix our issue in #379, this did. 

 