### PR TITLE
fix: insert [runners.{{ gitlab_runner.executor }}] after shell if present else after executor

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -164,7 +164,7 @@
     regexp: ^\s*\[runners\.{{ gitlab_runner.executor | default("shell") }}\]
     line: '  [runners.{{ gitlab_runner.executor | replace("docker+machine", "machine") | default("shell") }}]'
     state: "{{ 'absent' if (gitlab_runner.executor | default('shell')) == 'shell' else 'present' }}"
-    insertafter: ^\s*executor =
+    insertafter: ^\s*(shell|executor) =
     backrefs: false
   check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"


### PR DESCRIPTION
**Issue:**
A configuration like this:
```
gitlab_runner_runners:
  - name: "instance-powershell-runner"
    executor: "instance"
    shell: "powershell"
```
will create an incorrect `config.toml` like this:
```
[[runners]]
  name = "instance-powershell-runner"
  executor = "instance"
  [runners.instance]
  shell = "powershell"
```
because `[runners.{{ gitlab_runner.executor }}]` is inserted after `executor` even if `shell` is present.
Correct would be:
```
[[runners]]
  name = "instance-powershell-runner"
  executor = "instance"
  shell = "powershell"
  [runners.instance]
```

**Fix:**
Insert after `shell` or `executor`. If `shell` is present it will match last, and the line will be inserted after `shell`, otherwise the line will be inserted after `executor`.