### PR TITLE
fix: use explicit bool instead of implicit truthy

### DIFF
--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -131,7 +131,9 @@
     insertafter: ^\s*\[session_server\]
     state: present
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
-  when: gitlab_runner_session_server_session_timeout
+  when:
+    - gitlab_runner_session_server_session_timeout is defined
+    - gitlab_runner_session_server_session_timeout > 0
   become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner

--- a/tasks/systemd-reload.yml
+++ b/tasks/systemd-reload.yml
@@ -35,4 +35,4 @@
   become: true
   ansible.builtin.systemd:
     daemon_reload: true
-  when: gitlab_runner_exec_reload.changed or gitlab_runner_kill_timeout
+  when: gitlab_runner_exec_reload.changed or gitlab_runner_kill_timeout is defined

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -415,12 +415,13 @@
 - name: "Set additional services {{ runn_name_prefix }}"
   ansible.builtin.blockinfile:
     dest: "{{ temp_runner_config.path }}"
-    content: "{{ lookup('template', 'config.runners.docker.services.j2') if gitlab_runner.docker_services is defined }}"
+    content: "{{ lookup('template', 'config.runners.docker.services.j2') }}"
     state: "{{ 'present' if gitlab_runner.docker_services is defined else 'absent' }}"
     marker: "# {mark} runners.docker.services"
     insertafter: EOF
   check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  when: gitlab_runner.docker_services is defined
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -889,12 +890,13 @@
 - name: "Set feature flag options {{ runn_name_prefix }}"
   ansible.builtin.blockinfile:
     path: "{{ temp_runner_config.path }}"
-    content: "{{ lookup('template', 'config.runners.feature_flags.j2') if gitlab_runner.feature_flags is defined }}"
+    content: "{{ lookup('template', 'config.runners.feature_flags.j2') }}"
     state: "{{ 'present' if gitlab_runner.feature_flags is defined else 'absent' }}"
     marker: "# {mark} runners.feature_flags"
     insertafter: EOF
   check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  when: gitlab_runner.feature_flags is defined
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1060,12 +1062,13 @@
 - name: "Set additional autoscaling option {{ runn_name_prefix }}"
   ansible.builtin.blockinfile:
     dest: "{{ temp_runner_config.path }}"
-    content: "{{ lookup('template', 'config.runners.machine.autoscaling.j2') if gitlab_runner.machine_autoscaling is defined }}"
+    content: "{{ lookup('template', 'config.runners.machine.autoscaling.j2') }}"
     state: "{{ 'present' if gitlab_runner.machine_autoscaling is defined else 'absent' }}"
     marker: "# {mark} runners.machine.autoscaling"
     insertafter: EOF
   check_mode: false
   no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  when: gitlab_runner.machine_autoscaling is defined
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1111,14 +1114,14 @@
   loop:
     - '{{ gitlab_runner.builds_dir | default("") }}'
     - '{{ gitlab_runner.cache_dir | default("") }}'
-  when: item|length and gitlab_runner_verify_directories
+  when: (item | length > 0) and gitlab_runner_verify_directories
 
 - name: "Ensure directory access test {{ runn_name_prefix }}"
   ansible.builtin.command: test -r {{ item }}
   loop:
     - '{{ gitlab_runner.builds_dir | default("") }}'
     - '{{ gitlab_runner.cache_dir | default("") }}'
-  when: item|length and gitlab_runner_verify_directories
+  when: (item | length > 0) and gitlab_runner_verify_directories
   changed_when: false
   become: true
   become_user: "{{ gitlab_runner_runtime_owner | default(omit) }}"


### PR DESCRIPTION
# Why

With Ansible 2.19 implicit truthy is no longer allowed and ansible errors.
Changes

This commit adds explicit checks which returns boolean.

Also it is no longer allowed to add template logic to inline expressions. For example if conditions.

## Thoughts

I am not very familiar with the `blockinfile` module, but I do not see why the conditional should be in content instead of the when rule. If there is something special that I am not aware of, please correct me.

## Sources

https://ansible.readthedocs.io/projects/ansible-core/devel/porting_guides/porting_guide_core_2.19.html
