### PR TITLE
Improve systemd reload condition

### DIFF
--- a/tasks/systemd-reload.yml
+++ b/tasks/systemd-reload.yml
@@ -35,4 +35,7 @@
   become: true
   ansible.builtin.systemd:
     daemon_reload: true
-  when: gitlab_runner_exec_reload.changed or gitlab_runner_kill_timeout is defined
+  when: >-
+    gitlab_runner_exec_reload.changed or (
+      gitlab_runner_timeout_stop_seconds > 0 and gitlab_runner_kill_timeout.changed
+    )


### PR DESCRIPTION
Whether the copy changed something or not, its result will be a dict. Therefore, gitlab_runner_kill_timeout is defined whenever gitlab_runner_timeout_stop_seconds > 0 regardless of whether the file was updated. We'd really like to reload systemd when one of its configuration files has changed.

Fixes: 9e1dbb444926 ("fix: use explicit bool instead of implicit truthy")