### PR TITLE
Allow running role without global `become: true`

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -42,6 +42,7 @@
   ansible.builtin.dpkg_selections:
     name: "{{ gitlab_runner_package_name }}"
     selection: install
+  become: true
   when: "'gitlab-runner' in ansible_facts.packages"
 
 - name: (Debian) Unhold GitLab Runner Helper version
@@ -49,6 +50,7 @@
   ansible.builtin.dpkg_selections:
     name: "{{ gitlab_runner_helper_package_name }}"
     selection: install
+  become: true
   when:
     - ('gitlab-runner-helper-images' in ansible_facts.packages)
     - (gitlab_runner_package_version is undefined or gitlab_runner_package_version is version('17.7.0', '>='))
@@ -74,6 +76,7 @@
   ansible.builtin.dpkg_selections:
     name: "{{ gitlab_runner_package_name }}"
     selection: hold
+  become: true
   when: gitlab_runner_package_version is defined
   changed_when: false
 
@@ -81,6 +84,7 @@
   ansible.builtin.dpkg_selections:
     name: "{{ gitlab_runner_helper_package_name }}"
     selection: hold
+  become: true
   when: gitlab_runner_package_version is undefined or gitlab_runner_package_version is version('17.7.0', '>=')
   changed_when: false
 


### PR DESCRIPTION
Setting selections with dpkg requires root permissions, which were missing, and which triggers this kind of errors:

> fatal: [some-runner]: FAILED! => {"changed": false, "cmd": "/usr/bin/dpkg --set-selections", "msg": "dpkg: error: required read/write access to the dpkg database directory /var/lib/dpkg", "rc": 2, "stderr": "dpkg: error: required read/write access to the dpkg database directory /var/lib/dpkg\n", "stderr_lines": ["dpkg: error: required read/write access to the dpkg database directory /var/lib/dpkg"], "stdout": "", "stdout_lines": []}

This PR restores the functionality added a few years ago in https://github.com/riemers/ansible-gitlab-runner/pull/71, which allows for the role to be used without a global `become: true` permission.