### PR TITLE
Allow unregistering without global become: true

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -183,6 +183,7 @@
         dest: "{{ gitlab_runner_config_file_location }}/last-runner-config-{{ actual_gitlab_runner_name }}"
         mode: "0644"
       register: runner_config_state
+      become: "{{ gitlab_runner_system_mode }}"
 
     - name: Unregister runner
       ansible.builtin.import_tasks: unregister-runner.yml

--- a/tasks/unregister-runner.yml
+++ b/tasks/unregister-runner.yml
@@ -28,3 +28,4 @@
   ansible.builtin.command: "{{ gitlab_runner_executable }} unregister --name {{ actual_gitlab_runner_name }}"
   when:
     - gitlab_install_target_platform == 'unix'
+  become: "{{ gitlab_runner_system_mode }}"


### PR DESCRIPTION
If using `gitlab_runner_config_update_mode: 'by_registering'` and `gitlab_runner_system_mode: true` (the default), you'll need root permissions to unregister/register again.

This is a similar problem to the one fixed in https://github.com/riemers/ansible-gitlab-runner/pull/395.