### PR TITLE
Debian: Remove .bash_logout also for more recent distros (#137)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -121,6 +121,10 @@ gitlab_runner_verify_directories: true
 # controls logs on ansible configuration tasks, uncomment to prevent secret leaks (Unix support only).
 # gitlab_runner_no_log_secrets: yes
 
+# controls whether remove ~/.bash_logout from runner home directory
+# See https://docs.gitlab.com/runner/shells/#shell-profile-loading
+gitlab_runner_remove_bash_logout: false
+
 # A list of runners to register and configure
 gitlab_runner_runners:
   # The identifier of the runner.

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -88,11 +88,11 @@
   when: gitlab_runner_package_version is undefined or gitlab_runner_package_version is version('17.7.0', '>=')
   changed_when: false
 
-- name: (Debian) Remove ~/gitlab-runner/.bash_logout on debian buster and ubuntu focal, jammy and noble
+- name: (Debian) Remove ~/gitlab-runner/.bash_logout
   ansible.builtin.file:
     path: /home/gitlab-runner/.bash_logout
     state: absent
-  when: ansible_distribution_release in ["buster", "focal", "jammy", "noble"]
+  when: gitlab_runner_remove_bash_logout
 
 - name: Set systemd reload options
   ansible.builtin.import_tasks: systemd-reload.yml

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,3 +7,15 @@ gitlab_runner_runtime_group: gitlab-runner
 gitlab_runner_restart_state: reloaded
 
 tls_ca_file: /usr/share/ca-certificates/gitlab-server.crt
+
+# on debian buster and ubuntu focal, jammy and noble
+gitlab_runner_remove_bash_logout_releases:
+  - buster
+  - bullseye
+  - bookworm
+  - focal
+  - jammy
+  - noble
+
+gitlab_runner_remove_bash_logout:
+  "{{ ansible_distribution_release in gitlab_runner_remove_bash_logout_releases | default(false) }}"


### PR DESCRIPTION
Make "remove .bash_logout" more flexible.

Please see #137 and #138.