### PR TITLE
fix: Do not report changed for removed temp dir in check mode

### DIFF
--- a/tasks/config-runners-container.yml
+++ b/tasks/config-runners-container.yml
@@ -41,3 +41,5 @@
   ansible.builtin.file:
     path: "{{ temp_runner_config_dir.path }}"
     state: "absent"
+  check_mode: false
+  changed_when: false


### PR DESCRIPTION
This PR fixes the following "changed" task in check mode:

```
TASK [riemers.gitlab-runner : Remove temporary directory] ****************************************
--- before
+++ after
@@ -1,6 +1,2 @@
 path: /tmp/ansible.o70wwx41gitlab-runner-config
-path_content:
-  directories: []
-  files:
-  - /tmp/ansible.o70wwx41gitlab-runner-config/gitlab-runner.0.fn71nrwn
-state: directory
+state: absent

changed: [my.host.de]
```

The task should not report "changed", as it does not actually change any configuration on the target. Creation of the temporary directory is not reported as "changed" either.