### PR TITLE
fix: quote sysctl keys in config.toml template, so that the TOML is properly parsed by gitlab-runner 

### DIFF
--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -124,7 +124,7 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
 {% if gitlab_runner.docker_security_opt is defined %}
     security_opt = {{ gitlab_runner.docker_security_opt | tojson }}
 {% endif %}
-{% if gitlab_runner.extra_configs %}
+{% if gitlab_runner.extra_configs is defined %}
 {% if 'runners.docker' in gitlab_runner.extra_configs %}
 {% for key, value in gitlab_runner.extra_configs['runners.docker'].items() %}
     {{ key }} = {{ value | tojson }}


### PR DESCRIPTION
Due to the fact that the sysctl keys contain periods, like `net.ipv4.ip_forward`, we need to quote them, so that the TOML is properly parsed by gitlab-runner, like when using `gitlab-runner verify`.

Parsing error from `gitlab-runner verify`:

```shell
root@vps-0a441234:/home/ubuntu# gitlab-runner verify
Runtime platform                                    arch=amd64 os=linux pid=557091 revision=139a0ac0 version=18.4.0
Running in system-mode.

FATAL: decoding configuration file: toml: (last key "runners.docker.sysctls.net"): incompatible types: TOML value has type map[string]any; destination has type string
```

See also example at https://docs.gitlab.com/runner/configuration/advanced-configuration/

This is onlly relevant to configuration done via the template as per #400.