### PR TITLE
fix: ensure Gitlab runner repository GPG key is readable by everyone

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -19,6 +19,15 @@
   become: true
   when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 
+- name: Ensure Gitlab runner repository GPG key is readable by everyone
+  ansible.builtin.file:
+    path: /usr/share/keyrings/runner_gitlab-runner-archive-keyring.gpg
+    owner: root
+    group: root
+    mode: "0644"
+    state: file
+  when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
+
 - name: (Debian) Update gitlab_runner_package_name and gitlab_runner_helper_package_name
   ansible.builtin.set_fact:
     gitlab_runner_package: "{{ gitlab_runner_package_name }}={{ gitlab_runner_package_version }}"


### PR DESCRIPTION
When using this role in conjunction with https://github.com/dev-sec/ansible-collection-hardening/tree/master/roles/os_hardening, `os_hardening` sets up a restrictive umask of 027, compared to the usual 022, meaning that others won't have read access.

The result is that the /usr/share/keyrings/runner_gitlab-runner-archive-keyring.gpg will not be readable by others, preventing apt update to work and download the package.

Fixes #397