### PR TITLE
fix: remove lonely quote breaking the filename

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,7 @@ gitlab_runner_config_file: >-
   else (
     __gitlab_runner_config_file_system_mode if gitlab_runner_system_mode
     else __gitlab_runner_config_file_user_mode
-  ) }}"
+  ) }}
 gitlab_runner_config_file_location: "{{ gitlab_runner_config_file | dirname }}"
 gitlab_runner_executable: "{{ gitlab_runner_package_name }}"
 


### PR DESCRIPTION
The commit https://github.com/riemers/ansible-gitlab-runner/commit/4929c822a6e6c6531de2fe2b8a59134897a994a0#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4R29 introduced in #405 included a lonely double quote at the end, when testing while using the template-based configuration, it creates a new file `/etc/gitlab-runner/config.toml"`