### PR TITLE
fix: support full container registry URLs in autoscaler plugin config

### DIFF
--- a/templates/config.runners.autoscaler/autoscaler.j2
+++ b/templates/config.runners.autoscaler/autoscaler.j2
@@ -4,7 +4,7 @@
     max_use_count = {{ gitlab_runner.autoscaler.max_use_count }}
     max_instances = {{ gitlab_runner.autoscaler.max_instances }}
 
-    {{ lookup('template', 'config.runners.autoscaler/fleeting.plugin.' ~ gitlab_runner.autoscaler.plugin.split(':')[0] ~ '.j2') }}
+    {{ lookup('template', 'config.runners.autoscaler/fleeting.plugin.' ~ gitlab_runner.autoscaler.plugin.split('/')[-1].split(':')[0] ~ '.j2') }}
 
     [runners.autoscaler.connector_config]
     {% for key, value in gitlab_runner.autoscaler.connector_config.items() %}


### PR DESCRIPTION
Allow gitlab_runner.autoscaler.plugin to accept full container registry URLs.
e.g.:

> 123456789.dkr.ecr.eu-central-1.amazonaws.com/gitlab-org/fleeting/plugins/aws:latest

while still correctly resolving to the appropriate fleeting plugin template.

With this change all valid plugin formats are supported: https://docs.gitlab.com/runner/fleet_scaling/fleeting/#plugin-formats 