### PR TITLE
Add gitlab_runner.docker_services_devices

### DIFF
--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -48,6 +48,9 @@
       {% for device in gitlab_runner.docker_devices | default([]) %}
       --docker-devices "{{ device }}"
       {% endfor %}
+      {% for key, value in gitlab_runner.docker_services_devices | default({}) %}
+      --docker-services_devices "{{ key }}={{ value | tojson }}"
+      {% endfor %}
       {% if gitlab_runner.docker_network_mode is defined %}
       --docker-network-mode '{{ gitlab_runner.docker_network_mode }}'
       {% endif %}

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -39,6 +39,9 @@
       {% for device in gitlab_runner.docker_devices | default([]) %}
       --docker-devices "{{ device }}"
       {% endfor %}
+      {% for key, value in gitlab_runner.docker_services_devices | default({}) %}
+      --docker-services_devices "{{ key }}={{ value | tojson }}"
+      {% endfor %}
       {% if gitlab_runner.docker_network_mode is defined %}
       --docker-network-mode '{{ gitlab_runner.docker_network_mode }}'
       {% endif %}

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -87,6 +87,9 @@
       {% for device in gitlab_runner.docker_devices | default([]) %}
       --docker-devices "{{ device }}"
       {% endfor %}
+      {% for key, value in gitlab_runner.docker_services_devices | default({}) %}
+      --docker-services_devices "{{ key }}={{ value | tojson }}"
+      {% endfor %}
       {% if gitlab_runner.docker_network_mode is defined %}
       --docker-network-mode '{{ gitlab_runner.docker_network_mode }}'
       {% endif %}

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -439,6 +439,20 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
+#### [[runners.docker.services_devices]] section ####
+- name: "Set docker services devices {{ runn_name_prefix }}"
+  ansible.builtin.blockinfile:
+    dest: "{{ temp_runner_config.path }}"
+    content: "{{ lookup('template', 'config.runners.docker.services_devices.j2') if gitlab_runner.docker_services_devices is defined else omit }}"
+    state: "{{ 'present' if gitlab_runner.docker_services_devices is defined else 'absent' }}"
+    marker: "# {mark} runners.docker.services_devices"
+    insertafter: EOF
+  check_mode: false
+  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
+
 #### [runners.custom_build_dir] section #####
 - name: "Set custom_build_dir section {{ runn_name_prefix }}"
   ansible.builtin.lineinfile:

--- a/templates/config.runners.docker.services_devices.j2
+++ b/templates/config.runners.docker.services_devices.j2
@@ -1,0 +1,4 @@
+    [runners.docker.services_devices]
+{% for key, value in gitlab_runner.docker_services_devices %}
+      "{{ key }}" = {{ value | tojson }}
+{% endfor %}

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -33,20 +33,20 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
   limit = {{ gitlab_runner.concurrent_specific | default(0) }}
   url = {{ gitlab_runner.url | default(gitlab_runner_coordinator_url) | tojson }}
 {% if gitlab_runner.clone_url is defined %}
-  clone_url = {{ gitlab_runner.clone_url | tojson }} 
+  clone_url = {{ gitlab_runner.clone_url | tojson }}
 {% endif %}
   environment = {{ gitlab_runner.env_vars | default([]) | tojson }}
 {% if gitlab_runner.pre_get_sources_script is defined %}
-  pre_get_sources_script = {{ gitlab_runner.pre_get_sources_script | tojson }} 
+  pre_get_sources_script = {{ gitlab_runner.pre_get_sources_script | tojson }}
 {% endif %}
 {% if gitlab_runner.post_get_sources_script is defined %}
-  post_get_sources_script = {{ gitlab_runner.post_get_sources_script | tojson }} 
+  post_get_sources_script = {{ gitlab_runner.post_get_sources_script | tojson }}
 {% endif %}
 {% if gitlab_runner.pre_build_script is defined %}
-  pre_build_script  = {{ gitlab_runner.pre_build_script | tojson }} 
+  pre_build_script  = {{ gitlab_runner.pre_build_script | tojson }}
 {% endif %}
 {% if gitlab_runner.tls_ca_file is defined %}
-  tls-ca-file  = {{ gitlab_runner.tls_ca_file | tojson }} 
+  tls-ca-file  = {{ gitlab_runner.tls_ca_file | tojson }}
 {% endif %}
 {% if gitlab_runner.tls_cert_file is defined %}
     tls-cert-file = {{ gitlab_runner.tls_cert_file | default([]) | tojson }}
@@ -55,17 +55,17 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
     tls-key-file = {{ gitlab_runner.tls_key_file | default([]) | tojson }}
 {% endif %}
 {% if gitlab_runner.post_build_script is defined %}
-  post_build_script   = {{ gitlab_runner.post_build_script | tojson }} 
+  post_build_script   = {{ gitlab_runner.post_build_script | tojson }}
 {% endif %}
   executor = {{ gitlab_runner.executor | default("shell") | tojson }}
 {% if gitlab_runner.builds_dir is defined %}
-  builds_dir = {{ gitlab_runner.builds_dir | default("") | tojson }} 
+  builds_dir = {{ gitlab_runner.builds_dir | default("") | tojson }}
 {% endif %}
 {% if gitlab_runner.cache_dir is defined %}
-  cache_dir = {{ gitlab_runner.cache_dir | default("") | tojson }} 
+  cache_dir = {{ gitlab_runner.cache_dir | default("") | tojson }}
 {% endif %}
 {% if gitlab_runner.shell is defined %}
-  shell   = {{ gitlab_runner.shell | default("") | tojson }} 
+  shell   = {{ gitlab_runner.shell | default("") | tojson }}
 {% endif %}
   output_limit = {{ gitlab_runner.output_limit | default(4096) }}
   id = {{ gitlab_runner.id }}
@@ -150,6 +150,13 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
 {% endfor %}
 {% endfor %}
 {% endif %}
+{% endif %}
+{#### [runners.docker.services_devices] section ####}
+{% if gitlab_runner.docker_services_devices is defined %}
+    [runners.docker.services_devices]
+{% for key, value in gitlab_runner.docker_services_devices.items() %}
+      "{{ key }}" = {{ value | tojson }}
+{% endfor %}
 {% endif %}
 {#### [runners.ssh] section #####}
 {% if gitlab_runner.executor == "ssh" %}


### PR DESCRIPTION
This adds the capability to configure devices to add to service definitions, per gitlab-runner documentation. It can be configured via all gitlab_runner_config_update_mode modes.

The `keys` must be quoted as they are inputs such as `docker:dind`, and without them being quoted in the fragments, assemble bombs out

resolves: https://github.com/riemers/ansible-gitlab-runner/issues/415