### PR TITLE
Fix key=value for services_devices

### DIFF
--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -48,9 +48,6 @@
       {% for device in gitlab_runner.docker_devices | default([]) %}
       --docker-devices "{{ device }}"
       {% endfor %}
-      {% for key, value in gitlab_runner.docker_services_devices | default({}) %}
-      --docker-services_devices "{{ key }}={{ value | tojson }}"
-      {% endfor %}
       {% if gitlab_runner.docker_network_mode is defined %}
       --docker-network-mode '{{ gitlab_runner.docker_network_mode }}'
       {% endif %}

--- a/tasks/register-runner-windows.yml
+++ b/tasks/register-runner-windows.yml
@@ -39,9 +39,6 @@
       {% for device in gitlab_runner.docker_devices | default([]) %}
       --docker-devices "{{ device }}"
       {% endfor %}
-      {% for key, value in gitlab_runner.docker_services_devices | default({}) %}
-      --docker-services_devices "{{ key }}={{ value | tojson }}"
-      {% endfor %}
       {% if gitlab_runner.docker_network_mode is defined %}
       --docker-network-mode '{{ gitlab_runner.docker_network_mode }}'
       {% endif %}

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -87,9 +87,6 @@
       {% for device in gitlab_runner.docker_devices | default([]) %}
       --docker-devices "{{ device }}"
       {% endfor %}
-      {% for key, value in gitlab_runner.docker_services_devices | default({}) %}
-      --docker-services_devices "{{ key }}={{ value | tojson }}"
-      {% endfor %}
       {% if gitlab_runner.docker_network_mode is defined %}
       --docker-network-mode '{{ gitlab_runner.docker_network_mode }}'
       {% endif %}

--- a/templates/config.runners.docker.services_devices.j2
+++ b/templates/config.runners.docker.services_devices.j2
@@ -1,4 +1,4 @@
     [runners.docker.services_devices]
-{% for key, value in gitlab_runner.docker_services_devices %}
+{% for key, value in gitlab_runner.docker_services_devices.items() %}
       "{{ key }}" = {{ value | tojson }}
 {% endfor %}


### PR DESCRIPTION
@guenhter Thanks for the previous review, i was testing it locally and it appears the `''` bits are required so that both the CLI and the toml merging all work together (apologies on the previous being broken) - usually i open a Pull Request whilst still testing to get early feedback if anything might block etc