### PR TITLE
refactor(gitlab-runner): use ansible_facts dictionary syntax

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ gitlab_runner_config_file_location: "{{ gitlab_runner_config_file | dirname }}"
 gitlab_runner_executable: "{{ gitlab_runner_package_name }}"
 
 # Maximum number of global jobs to run concurrently
-gitlab_runner_concurrent: "{{ ansible_processor_vcpus }}"
+gitlab_runner_concurrent: "{{ ansible_facts['processor_vcpus'] }}"
 
 # Defines the interval length, in seconds, between the runner checking for new jobs.
 # The default value is 0. If set to 0 or lower, the default value of GitLab runner is used, which is 3.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,21 +6,21 @@
     state: "{{ gitlab_runner_restart_state }}"
   listen: restart_gitlab_runner
   become: true
-  when: ansible_os_family != 'Darwin' and ansible_os_family != 'Windows' and not gitlab_runner_container_install
+  when: ansible_facts['os_family'] != 'Darwin' and ansible_facts['os_family'] != 'Windows' and not gitlab_runner_container_install
 
 # macOS
 - name: Restart_gitlab_runner_macos
   ansible.builtin.command: "{{ gitlab_runner_executable }} restart"
   listen: restart_gitlab_runner_macos
   become: "{{ gitlab_runner_system_mode }}"
-  when: ansible_os_family == 'Darwin' and gitlab_runner_macos_start_runner
+  when: ansible_facts['os_family'] == 'Darwin' and gitlab_runner_macos_start_runner
 
 - name: Restart_gitlab_runner_windows
   ansible.windows.win_command: "{{ gitlab_runner_executable }} restart"
   args:
     chdir: "{{ gitlab_runner_config_file_location }}"
   listen: restart_gitlab_runner_windows
-  when: ansible_os_family == 'Windows' and gitlab_runner_windows_start_runner
+  when: ansible_facts['os_family'] == 'Windows' and gitlab_runner_windows_start_runner
 
 # Container
 - name: Restart_gitlab_runner_container

--- a/tasks/config-runner.yml
+++ b/tasks/config-runner.yml
@@ -22,7 +22,7 @@
   vars:
     runn_name_prefix: "{{ conf_name_prefix }} runner[{{ (gitlab_runner_index | int) + 1 }}/{{ gitlab_runner_runners | length }}]:"
   when:
-    - ('name = "'+gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)+'"') in runner_config
+    - ('name = "'+gitlab_runner.name|default(ansible_facts["hostname"]+'-'+gitlab_runner_index|string)+'"') in runner_config
     - gitlab_runner.state|default('present') == 'present'
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
@@ -35,7 +35,7 @@
     path: "{{ temp_runner_config.path }}"
     state: absent
   when:
-    - ('name = "'+gitlab_runner.name|default(ansible_hostname+'-'+gitlab_runner_index|string)+'"') in runner_config
+    - ('name = "'+gitlab_runner.name|default(ansible_facts["hostname"]+'-'+gitlab_runner_index|string)+'"') in runner_config
     - gitlab_runner.state|default('present') == 'absent'
   loop: "{{ gitlab_runner_runners }}"
   loop_control:

--- a/tasks/main-unix.yml
+++ b/tasks/main-unix.yml
@@ -1,19 +1,19 @@
 ---
 - name: Install GitLab Runner (Debian)
   ansible.builtin.include_tasks: install-debian.yml
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Install GitLab Runner (RedHat)
   ansible.builtin.include_tasks: install-redhat.yml
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Install GitLab Runner (macOS)
   ansible.builtin.include_tasks: install-macos.yml
-  when: ansible_os_family == 'Darwin'
+  when: ansible_facts['os_family'] == 'Darwin'
 
 - name: Install GitLab Runner (Arch)
   ansible.builtin.include_tasks: install-arch.yml
-  when: ansible_os_family == 'Archlinux'
+  when: ansible_facts['os_family'] == 'Archlinux'
 
 - name: (Unix) Delete runners which were removed in GitLab
   ansible.builtin.command: "{{ gitlab_runner_executable }} verify --delete"
@@ -28,7 +28,7 @@
 - name: (Unix) Register GitLab Runner
   ansible.builtin.include_tasks: register-runner.yml
   vars:
-    actual_gitlab_runner_name: "{{ gitlab_runner.name | default(ansible_hostname + '-' + gitlab_runner_index | string) }}"
+    actual_gitlab_runner_name: "{{ gitlab_runner.name | default(ansible_facts['hostname'] + '-' + gitlab_runner_index | string) }}"
   when: gitlab_runner.token is defined or gitlab_runner_registration_token | string | length > 0
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
@@ -43,7 +43,7 @@
 - name: Set global options (macOS/Debian/RedHat)
   ansible.builtin.import_tasks: global-setup.yml
   when: gitlab_runner_config_update_mode == 'by_config_toml' or
-        gitlab_runner_config_update_mode == 'by_registering'
+    gitlab_runner_config_update_mode == 'by_registering'
 
 - name: (Unix) Configure GitLab Runner
   ansible.builtin.include_tasks: config-runners.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,8 @@
   vars:
     possible_files:
       files:
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
         - default.yml
       paths:
         - vars
@@ -13,7 +13,7 @@
 - name: Validate GitLab Runner configurations
   ansible.builtin.include_tasks: validate-runner-config.yml
   vars:
-    actual_gitlab_runner_name: "{{ gitlab_runner.name | default(ansible_hostname + '-' + gitlab_runner_index | string) }}"
+    actual_gitlab_runner_name: "{{ gitlab_runner.name | default(ansible_facts['hostname'] + '-' + gitlab_runner_index | string) }}"
   loop: "{{ gitlab_runner_runners }}"
   loop_control:
     label: "{{ actual_gitlab_runner_name }}"
@@ -30,10 +30,10 @@
   vars:
     gitlab_install_target_platform: unix
   ansible.builtin.include_tasks: main-unix.yml
-  when: ansible_os_family != 'Windows' and not gitlab_runner_container_install
+  when: ansible_facts['os_family'] != 'Windows' and not gitlab_runner_container_install
 
 - name: Install GitLab Runner (Windows)
   vars:
     gitlab_install_target_platform: windows
   ansible.builtin.include_tasks: main-windows.yml
-  when: ansible_os_family == 'Windows' and not gitlab_runner_container_install
+  when: ansible_facts['os_family'] == 'Windows' and not gitlab_runner_container_install

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,4 @@
 ---
-
 gitlab_runner_executable: /usr/bin/{{ gitlab_runner_package_name }}
 
 gitlab_runner_runtime_owner: gitlab-runner
@@ -17,5 +16,6 @@ gitlab_runner_remove_bash_logout_releases:
   - jammy
   - noble
 
-gitlab_runner_remove_bash_logout:
-  "{{ ansible_distribution_release in gitlab_runner_remove_bash_logout_releases | default(false) }}"
+gitlab_runner_remove_bash_logout: >-
+  {{ ansible_facts['distribution_release']
+    in gitlab_runner_remove_bash_logout_releases | default(false) }}


### PR DESCRIPTION
Replace deprecated Ansible magic variables with explicit ansible_facts dictionary references throughout the role. This modernizes the code to align with current Ansible best practices and improves clarity by making fact sources explicit.

* Replace all magic variable references with ansible_facts syntax
  * ansible_processor_vcpus → ansible_facts['processor_vcpus']
  * ansible_os_family → ansible_facts['os_family']
  * ansible_hostname → ansible_facts['hostname']
  * ansible_distribution → ansible_facts['distribution']
  * ansible_distribution_release → ansible_facts['distribution_release']
* Apply changes across defaults, handlers, tasks, and vars files
* Improve YAML formatting in vars/Debian.yml
  * Remove extra blank line at top of file
  * Reformat gitlab_runner_remove_bash_logout to multi-line syntax
* Fix indentation alignment in tasks/main-unix.yml when condition