### PR TITLE
fix error with non existing variable 'runner_config_file_path'

### DIFF
--- a/tasks/template_config/main.yml
+++ b/tasks/template_config/main.yml
@@ -4,7 +4,7 @@
   block:
     - name: '(Update config: template) Read config.toml file'
       ansible.builtin.slurp:
-        src: "{{ runner_config_file_path }}"
+        src: "{{ gitlab_runner_config_file }}"
       register: runner_config_file
 
     - name: '(Update config: template) Retrieve runners configuration content'


### PR DESCRIPTION
Hello. 
I find some spare time to test templates approach and on first run it hits error with non existing variable.
There is a fix which works for me. This fix needs review if it is valid for other scenarios and platforms.
