### PR TITLE
Make gitlab_runner_session_server_session_timeout conditional explicit

### DIFF
--- a/tasks/global-setup-windows.yml
+++ b/tasks/global-setup-windows.yml
@@ -91,7 +91,9 @@
     line: "  session_timeout = {{ gitlab_runner_session_server_session_timeout }}"
     insertafter: ^\s*\[session_server\]
     state: present
-  when: gitlab_runner_session_server_session_timeout
+  when:
+    - gitlab_runner_session_server_session_timeout is defined
+    - gitlab_runner_session_server_session_timeout > 0
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos


### PR DESCRIPTION
Ansible core 2.19+ disallows non-boolean values in `when` expressions. Replace integer-based conditional with explicit `is defined` and `> 0` checks to comply with the updated broken conditionals behavior.

https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.19.html#broken-conditionals