### PR TITLE
fix: deprecation warnings in 2.19

### DIFF
--- a/tasks/config-runner.yml
+++ b/tasks/config-runner.yml
@@ -15,7 +15,7 @@
     mode: "0644"
   check_mode: false
   changed_when: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
 
 - name: "Update config"
   ansible.builtin.include_tasks: update-config-runner.yml
@@ -28,7 +28,7 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
 
 - name: "Remove runner config {{ conf_name_prefix }}"
   ansible.builtin.file:
@@ -41,4 +41,4 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"

--- a/tasks/config-runners.yml
+++ b/tasks/config-runners.yml
@@ -8,7 +8,7 @@
 - name: "Get pre-existing runner configs"
   ansible.builtin.set_fact:
     runner_configs: "{{ (runner_config_file['content'] | b64decode).split('[[runners]]\n') }}"
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
 
 - name: "Create temporary directory"
   ansible.builtin.tempfile:
@@ -26,7 +26,7 @@
   loop_control:
     index_var: runner_config_index
     loop_var: runner_config
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
 
 - name: "Assemble new config.toml"
   ansible.builtin.assemble:

--- a/tasks/global-setup-windows.yml
+++ b/tasks/global-setup-windows.yml
@@ -30,7 +30,7 @@
     line: check_interval = {{ gitlab_runner_check_interval }}
     insertafter: \s*concurrent.*
     state: present
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_windows

--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -23,7 +23,7 @@
     line: \1concurrent = {{ gitlab_runner_concurrent }}
     state: present
     backrefs: true
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
@@ -36,7 +36,7 @@
     line: check_interval = {{ gitlab_runner_check_interval }}
     insertafter: \s*concurrent.*
     state: present
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
@@ -49,7 +49,7 @@
     line: listen_address = "{{ gitlab_runner_listen_address }}"
     insertafter: \s*concurrent.*
     state: present
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   when: gitlab_runner_listen_address | length > 0
   become: "{{ gitlab_runner_system_mode }}"
   notify:
@@ -63,7 +63,7 @@
     line: log_format = "{{ gitlab_runner_log_format | default("runner") }}"
     insertbefore: BOF
     state: present
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   when: gitlab_runner_log_format is defined
   become: "{{ gitlab_runner_system_mode }}"
   notify:
@@ -77,7 +77,7 @@
     line: log_level = "{{ gitlab_runner_log_level }}"
     insertbefore: BOF
     state: present
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   when: gitlab_runner_log_level is defined
   become: "{{ gitlab_runner_system_mode }}"
   notify:
@@ -91,7 +91,7 @@
     line: sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
     insertafter: \s*concurrent.*
     state: present
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   when: gitlab_runner_sentry_dsn | length > 0
   become: "{{ gitlab_runner_system_mode }}"
   notify:
@@ -105,7 +105,7 @@
     line: '  listen_address = "{{ gitlab_runner_session_server_listen_address }}"'
     insertafter: ^\s*\[session_server\]
     state: "{{ 'present' if gitlab_runner_session_server_listen_address | length > 0 else 'absent' }}"
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   become: "{{ gitlab_runner_system_mode }}"
   notify:
     - restart_gitlab_runner
@@ -119,7 +119,7 @@
     insertafter: ^\s*\[session_server\]
     state: "{{ 'present' if gitlab_runner_session_server_advertise_address | length > 0 else 'absent' }}"
   become: "{{ gitlab_runner_system_mode }}"
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -131,7 +131,7 @@
     line: "  session_timeout = {{ gitlab_runner_session_server_session_timeout }}"
     insertafter: ^\s*\[session_server\]
     state: present
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   when:
     - gitlab_runner_session_server_session_timeout is defined
     - gitlab_runner_session_server_session_timeout > 0

--- a/tasks/list-configured-runners-unix.yml
+++ b/tasks/list-configured-runners-unix.yml
@@ -17,7 +17,7 @@
     json_item: "{{ item | from_json }}"
   loop: "{{ registered_runners_json_result.stderr_lines }}"
   when: "'Executor' in json_item"
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
 
 - name: "Print registered runners"
   ansible.builtin.debug:

--- a/tasks/main-unix.yml
+++ b/tasks/main-unix.yml
@@ -34,7 +34,7 @@
   loop_control:
     index_var: gitlab_runner_index
     loop_var: gitlab_runner
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
 
 - name: Unregister runners which are not longer configured
   ansible.builtin.include_tasks: unregister-runner-if-not-longer-configured.yml

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -8,7 +8,7 @@
     insertafter: ^\s*name =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -22,7 +22,7 @@
     insertafter: ^\s*limit =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -36,7 +36,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -51,7 +51,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -65,7 +65,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -94,7 +94,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -109,7 +109,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -124,7 +124,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -139,7 +139,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -153,7 +153,7 @@
     insertafter: ^\s*executor =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -167,7 +167,7 @@
     insertafter: ^\s*(shell|executor) =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -181,7 +181,7 @@
     insertafter: ^\s*executor =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -196,7 +196,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -210,7 +210,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -224,7 +224,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -238,7 +238,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -252,7 +252,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -266,7 +266,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -280,7 +280,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -294,7 +294,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -308,7 +308,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -322,7 +322,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -336,7 +336,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -350,7 +350,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -364,7 +364,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -378,7 +378,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -392,7 +392,7 @@
     insertafter: ^\s*\[runners\.docker\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -406,7 +406,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -420,7 +420,7 @@
     insertafter: ^\s*url =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -434,7 +434,7 @@
     marker: "# {mark} runners.docker.services"
     insertafter: EOF
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -448,7 +448,7 @@
     marker: "# {mark} runners.docker.services_devices"
     insertafter: EOF
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -463,7 +463,7 @@
     insertafter: EOF
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -477,7 +477,7 @@
     insertafter: ^\s*\[runners\.custom_build_dir\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -492,7 +492,7 @@
     insertafter: EOF
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -506,7 +506,7 @@
     insertafter: ^\s*\[runners\.cache\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -520,7 +520,7 @@
     insertafter: ^\s*\[runners\.cache\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -534,7 +534,7 @@
     insertafter: ^\s*\[runners\.cache\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -548,7 +548,7 @@
     insertafter: ^\s*\[runners\.cache\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -562,7 +562,7 @@
     insertafter: ^\s*\[runners\.cache\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -576,7 +576,7 @@
     insertafter: ^\s*\[runners\.cache\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -591,7 +591,7 @@
     insertafter: ^\s*\[runners\.cache\.s3\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -605,7 +605,7 @@
     insertafter: ^\s*\[runners\.cache\.s3\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -619,7 +619,7 @@
     insertafter: ^\s*\[runners\.cache\.s3\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -633,7 +633,7 @@
     insertafter: ^\s*\[runners\.cache\.s3\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -648,7 +648,7 @@
     insertafter: ^\s*\[runners\.cache\.s3\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -662,7 +662,7 @@
     insertafter: ^\s*\[runners\.cache\.s3\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -691,7 +691,7 @@
     insertafter: ^\s*\[runners\.cache\.gcs\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -705,7 +705,7 @@
     insertafter: ^\s*\[runners\.cache\.gcs\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -719,7 +719,7 @@
     insertafter: ^\s*\[runners\.cache\.gcs\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -734,7 +734,7 @@
     insertafter: ^\s*\[runners\.cache\.azure\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -748,7 +748,7 @@
     insertafter: ^\s*\[runners\.cache\.azure\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -762,7 +762,7 @@
     insertafter: ^\s*\[runners\.cache\.azure\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -776,7 +776,7 @@
     insertafter: ^\s*\[runners\.cache\.azure\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -791,7 +791,7 @@
     insertafter: ^\s*\[runners\.ssh\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -805,7 +805,7 @@
     insertafter: ^\s*\[runners\.ssh\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -819,7 +819,7 @@
     insertafter: ^\s*\[runners\.ssh\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -833,7 +833,7 @@
     insertafter: ^\s*\[runners\.ssh\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -847,7 +847,7 @@
     insertafter: ^\s*\[runners\.ssh\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -862,7 +862,7 @@
     insertafter: ^\s*\[runners\.virtualbox\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   when: gitlab_runner.executor == 'virtualbox' and gitlab_runner.virtualbox_base_name is defined
   notify:
     - restart_gitlab_runner
@@ -877,7 +877,7 @@
     insertafter: ^\s*\[runners\.virtualbox\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   when: gitlab_runner.executor == 'virtualbox' and gitlab_runner.virtualbox_base_name is defined
   notify:
     - restart_gitlab_runner
@@ -893,7 +893,7 @@
     backrefs: false
   check_mode: false
   when: gitlab_runner.executor == 'virtualbox' and gitlab_runner.virtualbox_base_name is defined
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -907,7 +907,7 @@
     insertafter: ^\s*\[runners\.virtualbox\]
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   when: gitlab_runner.executor == 'virtualbox' and gitlab_runner.virtualbox_base_name is defined
   notify:
     - restart_gitlab_runner
@@ -922,7 +922,7 @@
     marker: "# {mark} runners.feature_flags"
     insertafter: EOF
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -937,7 +937,7 @@
     insertafter: EOF
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -951,7 +951,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -965,7 +965,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -979,7 +979,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -993,7 +993,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1007,7 +1007,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1021,7 +1021,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1035,7 +1035,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1049,7 +1049,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1063,7 +1063,7 @@
     insertafter: '^\s*\[runners\.machine\]'
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1078,7 +1078,7 @@
     marker: "# {mark} runners.autoscaler"
     insertafter: EOF
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1093,7 +1093,7 @@
     marker: "# {mark} runners.machine.autoscaling"
     insertafter: EOF
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1107,7 +1107,7 @@
     insertafter: ^\s*executor =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
@@ -1121,7 +1121,7 @@
     insertafter: ^\s*executor =
     backrefs: false
   check_mode: false
-  no_log: "{{ gitlab_runner_no_log_secrets | default(omit) }}"
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
   notify:
     - restart_gitlab_runner
     - restart_gitlab_runner_macos


### PR DESCRIPTION
```
[WARNING]: Callback dispatch 'v2_runner_on_ok' failed for plugin 'default': Type 'type' is unsupported for variable storage.
Callback dispatch 'v2_runner_on_ok' failed for plugin 'default'.
<<< caused by >>>
Type 'type' is unsupported for variable storage.
Origin: <unknown>
<class 'ansible.module_utils.common.sentinel.Sentinel'>

```