### PR TITLE
manage request_concurrency parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ gitlab_runner_runners:
     token: 'abcd'
     # url is an optional override to the global gitlab_runner_coordinator_url
     url: 'https://my-own-gitlab.mydomain.com'
+    request_concurrency: 2
     executor: docker
     docker_image: 'alpine'
     tags:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -154,6 +154,9 @@ gitlab_runner_runners:
     # Maximum number of jobs to run concurrently on this specific runner.
     # Defaults to 0, simply means don't limit.
     concurrent_specific: "0"
+    # Limits concurrent HTTP requests to GitLab API per runner configuration
+    # See at https://support.gitlab.com/hc/en-us/articles/21324350882076-GitLab-Runner-Concurrency-Tuning-Understanding-request-concurrency
+    # request_concurrency:
     # The default Docker image to use. Required when executor is `docker`.
     docker_image: ""
     # Set to override the default helper image that is used.

--- a/tasks/update-config-runner-windows.yml
+++ b/tasks/update-config-runner-windows.yml
@@ -21,6 +21,19 @@
   check_mode: false
   notify: restart_gitlab_runner_windows
 
+- name: "Set request concurrency option {{ runn_name_prefix }}"
+  community.windows.win_lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: ^\s*request_concurrency =
+    line: "  request_concurrency = {{ gitlab_runner.request_concurrency }}"
+    state: present
+    insertafter: ^\s*limit =
+    backrefs: false
+  check_mode: false
+  notify:
+    - restart_gitlab_runner_windows
+  when: gitlab_runner.request_concurrency is defined
+
 - name: "Set coordinator URL {{ runn_name_prefix }}"
   community.windows.win_lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -13,6 +13,21 @@
     - restart_gitlab_runner
     - restart_gitlab_runner_macos
 
+- name: "Set request concurrency option {{ runn_name_prefix }}"
+  ansible.builtin.lineinfile:
+    dest: "{{ temp_runner_config.path }}"
+    regexp: ^\s*request_concurrency =
+    line: "  request_concurrency = {{ gitlab_runner.request_concurrency }}"
+    state: present
+    insertafter: ^\s*limit =
+    backrefs: false
+  check_mode: false
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
+  when: gitlab_runner.request_concurrency is defined
+
 - name: "Set coordinator URL {{ runn_name_prefix }}"
   ansible.builtin.lineinfile:
     dest: "{{ temp_runner_config.path }}"

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -31,6 +31,9 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
 [[runners]]
   name = {{ gitlab_runner.name | tojson }}
   limit = {{ gitlab_runner.concurrent_specific | default(0) }}
+{% if gitlab_runner.request_concurrency is defined %}
+  request_concurrency = {{ gitlab_runner.request_concurrency | tojson }}
+{% endif %}
   url = {{ gitlab_runner.url | default(gitlab_runner_coordinator_url) | tojson }}
 {% if gitlab_runner.clone_url is defined %}
   clone_url = {{ gitlab_runner.clone_url | tojson }}


### PR DESCRIPTION
Wirh this patch you can add the `request_concurrency` paramenter in `gitlab_runner_runners`.

For example:

        gitlab_runner_runners:
          - name: Shared Runner
            executor: docker
            concurrent_specific: "8"
            request_concurrency: "2"

will result in

```
[[runners]]
  name = "Shared Runner
  limit = 8
  request_concurrency = 2
```
