### PR TITLE
Fix bug in custom_build_dir_enabled

### DIFF
--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -202,11 +202,11 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
 {% if gitlab_runner.virtualbox_disable_snapshots is defined %}
     disable_snapshots = {{ gitlab_runner.virtualbox_disable_snapshots | default(false) | lower }}
 {% endif %}
+{% endif %}
 {#### [runners.custom_build_dir] section #####}
 {% if gitlab_runner.custom_build_dir_enabled is defined %}
   [runners.custom_build_dir]
     enabled = {{ gitlab_runner.custom_build_dir_enabled | default(false) | lower }}
-{% endif %}
 {% endif %}
 {#### [runners.cache] section ####}
   [runners.cache]


### PR DESCRIPTION
If you were not using virtualbox executor, custom_build_dir_enabled was never considered, as the if-endif nesting was wrong.