### PR TITLE
Use a macro for extras_config, fixes #432

### DIFF
--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -258,6 +258,8 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
     {{ flag }} = true
 {% endfor %}
 {% endif %}
+{#### [runners.custom] section ####}
+{{ extras_config(gitlab_runner, "runners.custom", indentation=2) }}
 {#### [runners.machine] section ####}
 {% if gitlab_runner.machine_MachineOptions is defined %}
   [runners.machine]

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -1,3 +1,4 @@
+{%- from "toml_macros.j2" import extras_config with context -%}
 concurrent = {{ gitlab_runner_concurrent }}
 {% if gitlab_runner_check_interval is defined %}
 check_interval = {{ gitlab_runner_check_interval }}
@@ -130,27 +131,11 @@ sentry_dsn = "{{ gitlab_runner_sentry_dsn }}"
 {% if gitlab_runner.docker_security_opt is defined %}
     security_opt = {{ gitlab_runner.docker_security_opt | tojson }}
 {% endif %}
-{% if gitlab_runner.extra_configs is defined %}
-{% if 'runners.docker' in gitlab_runner.extra_configs %}
-{% for key, value in gitlab_runner.extra_configs['runners.docker'].items() %}
-    {{ key }} = {{ value | tojson }}
-{% endfor %}
-{% endif %}
+{{ extras_config(gitlab_runner, "runners.docker", indentation=2, announce_section=False) }}
 {#### [runners.docker.sysctls] section ####}
-{% if 'runners.docker.sysctls' in gitlab_runner.extra_configs %}
-    [runners.docker.sysctls]
-{% for key, value in gitlab_runner.extra_configs['runners.docker.sysctls'].items() %}
-      "{{ key }}" = {{ value | tojson }}
-{% endfor %}
-{% endif %}
+{{ extras_config(gitlab_runner, "runners.docker.sysctls", indentation=2) }}
 {#### [runners.docker.container_labels] section ####}
-{% if 'runners.docker.container_labels' in gitlab_runner.extra_configs %}
-    [runners.docker.container_labels]
-{% for key, value in gitlab_runner.extra_configs['runners.docker.container_labels'].items() %}
-      "{{ key }}" = {{ value | tojson }}
-{% endfor %}
-{% endif %}
-{% endif %}
+{{ extras_config(gitlab_runner, "runners.docker.container_labels", indentation=2) }}
 {#### [[runners.docker.services]] section ####}
 {% if gitlab_runner.docker_services is defined %}
 {% for service in gitlab_runner.docker_services %}

--- a/templates/toml_macros.j2
+++ b/templates/toml_macros.j2
@@ -1,0 +1,10 @@
+{% macro extras_config(gitlab_runner, extra_key, indentation=0, announce_section=True) %}
+{% if gitlab_runner.extra_configs is defined and extra_key in gitlab_runner.extra_configs.keys() %}
+{% if announce_section %}
+{{ " " * indentation }}[{{ extra_key }}]
+{% endif %}
+{% for key, value in gitlab_runner.extra_configs[extra_key].items() %}
+{{ " " * (indentation + 2) }}{{ key }} = {{ value | tojson }}
+{% endfor %}
+{% endif %}
+{% endmacro %}


### PR DESCRIPTION
This PR adds functionality to create a custom executor via this role. It fixes #432 via template. 

@guenhter, @riemers I've seen there's another way of updating config files implemented as well. I'm not sure how to handle it in `update-config-runner.yml` and `update-runner-config-windows.yml` as this feature did never exist before. Any hints?