### PR TITLE
Introduce gitlab_runner_macos_install_from_homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Role Variables
 - `gitlab_runner_wanted_version` or `gitlab_runner_package_version` - Use these to install a specific version of the GitLab Runner (by default, the latest version is installed). 
   - On macOS and Windows, use `gitlab_runner_wanted_version: 12.4.1` (example).
   - On Linux, use `gitlab_runner_package_version` instead.
+- `gitlab_runner_macos_install_from_homebrew` - macOS-only switch to install/upgrade GitLab Runner via Homebrew instead of downloading from `gitlab_runner_download_url` (default: `false`).
+  - When installing via brew, `gitlab_runner_wanted_version` is currently ignored.
 - `gitlab_runner_concurrent` - Defines the maximum number of jobs that can run concurrently. Defaults to the number of processor cores.
 - `gitlab_runner_registration_token` - The GitLab registration token. If specified, this will register each runner with a GitLab server. **Note**: This token can only be used globally if `gitlab_runner_registration_token_type` is set to the deprecated `registration-token`. Otherwise, you must specify a `token` for each item in `gitlab_runner_runners`, as shown in the example playbook below. This token is deprecated in GitLab version 16.0 and will be removed in version 18.0.
 - `gitlab_runner_registration_token_type` - Specifies the type of registration token to use for GitLab Runner registration:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,6 +89,9 @@ gitlab_runner_windows_service_password: ""
 # https://docs.gitlab.com/runner/install/osx.html#limitations-on-macos
 gitlab_runner_macos_start_runner: true
 
+# Whether to install GitLab Runner on macOS via Homebrew instead of download URL.
+gitlab_runner_macos_install_from_homebrew: false
+
 # Whether to try to start the runner on Windows.
 # If set to `false`, it should be started manually.
 gitlab_runner_windows_start_runner: true

--- a/tasks/install-macos.yml
+++ b/tasks/install-macos.yml
@@ -23,7 +23,9 @@
         gitlab_runner_existing_version: "{{ existing_version_shell.stdout if existing_version_shell.rc == 0 else '0' }}"
 
 - name: "(MacOS) Precreate necessary directories for arm64 architecture"
-  when: gitlab_runner_arch == 'arm64'
+  when:
+    - gitlab_runner_arch == 'arm64'
+    - not gitlab_runner_macos_install_from_homebrew
   block:
     - name: "(MacOS) Precreate gitlab-runner log directory"
       become: true
@@ -45,12 +47,19 @@
   when: (not gitlab_runner_exists)
   block:
     - name: "(MacOS) Download GitLab Runner"
+      when: not gitlab_runner_macos_install_from_homebrew
       become: true
       ansible.builtin.get_url:
         url: "{{ gitlab_runner_download_url }}"
         dest: "{{ gitlab_runner_executable }}"
         force: true
         mode: +x
+
+    - name: "(MacOS) Install GitLab Runner via Homebrew"
+      when: gitlab_runner_macos_install_from_homebrew
+      ansible.builtin.package:
+        name: "{{ gitlab_runner_package_name }}"
+        state: present
 
     - name: "(MacOS) Install GitLab Runner"
       ansible.builtin.command: |
@@ -72,6 +81,7 @@
       ansible.builtin.command: "{{ gitlab_runner_executable }} stop"
 
     - name: "(MacOS) Download GitLab Runner"
+      when: not gitlab_runner_macos_install_from_homebrew
       become: true
       ansible.builtin.get_url:
         url: "{{ gitlab_runner_download_url }}"
@@ -79,7 +89,14 @@
         force: true
         mode: "0744"
 
+    - name: "(MacOS) Upgrade GitLab Runner via Homebrew"
+      when: gitlab_runner_macos_install_from_homebrew
+      ansible.builtin.package:
+        name: "{{ gitlab_runner_package_name }}"
+        state: latest
+
     - name: "(MacOS) Setting Permissions for gitlab-runner executable"
+      when: not gitlab_runner_macos_install_from_homebrew
       ansible.builtin.file:
         path: "{{ gitlab_runner_executable }}"
         owner: "{{ ansible_user_id | string }}"

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -7,7 +7,7 @@ gitlab_runner_system_mode: false
 gitlab_runner_download_url: "https://gitlab-runner-downloads.s3.amazonaws.com/\
   {{ gitlab_runner_wanted_tag }}/binaries/gitlab-runner-darwin-{{ gitlab_runner_arch }}"
 
-gitlab_runner_directory: /usr/local/bin
+gitlab_runner_directory: "{{ '/opt/homebrew/bin' if (gitlab_runner_macos_install_from_homebrew and gitlab_runner_arch == 'arm64') else '/usr/local/bin' }}"
 gitlab_runner_executable: "{{ gitlab_runner_directory }}/{{ gitlab_runner_package_name }}"
 
 # working directory for gitlab runner. defaults to current directory


### PR DESCRIPTION
This PR introduces `gitlab_runner_macos_install_from_homebrew`, which will install and upgrade `gitlab-runner` via Homebrew instead of `gitlab_runner_download_url`.

Using the brew-sourced binary comes with additional fixes that the Gitlab team doesnt care for or is dragging their feet on, e.g.
https://gitlab.com/gitlab-org/gitlab-runner/-/work_items/38396
https://gitlab.com/gitlab-org/gitlab-runner/-/work_items/3463
