### PR TITLE
container: remove anonymous volumes

### DIFF
--- a/tasks/list-configured-runners-container.yml
+++ b/tasks/list-configured-runners-container.yml
@@ -9,6 +9,7 @@
         source: "{{ gitlab_runner_container_mount_path }}"
         target: /etc/gitlab-runner
     cleanup: true
+    keep_volumes: false
     interactive: true
     tty: true
     detach: false

--- a/tasks/main-container.yml
+++ b/tasks/main-container.yml
@@ -13,6 +13,7 @@
         source: "{{ gitlab_runner_container_mount_path }}"
         target: /etc/gitlab-runner
     cleanup: true
+    keep_volumes: false
     interactive: true
     tty: true
     detach: false

--- a/tasks/register-runner-container.yml
+++ b/tasks/register-runner-container.yml
@@ -176,6 +176,7 @@
         source: "{{ gitlab_runner_container_mount_path }}"
         target: /etc/gitlab-runner
     cleanup: true
+    keep_volumes: false
     auto_remove: true
     network_mode: "{{ gitlab_runner_container_network }}"
   when:

--- a/tasks/unregister-runner.yml
+++ b/tasks/unregister-runner.yml
@@ -9,6 +9,7 @@
         source: "{{ gitlab_runner_container_mount_path }}"
         target: /etc/gitlab-runner
     cleanup: true
+    keep_volumes: false
     interactive: true
     tty: true
     detach: false


### PR DESCRIPTION
gitlab-runner container is executed multiple times to perform some actions and it creates 2 anonymous volumes for
- /etc/gitlab-runner
- /home/gitlab-runner"

By default "community.docker.docker_container" role "Retains anonymous volumes associated with a removed container.":

https://docs.ansible.com/projects/ansible/latest/collections/community/docker/docker_container_module.html#parameter-keep_volumes

so 2 empty volumes are left from each container run.