### PR TITLE
Run GitLab's repository install script every time instead of package cache refreshing

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -1,10 +1,4 @@
 ---
-- name: "(Debian) Refresh package cache"
-  ansible.builtin.apt:
-    cache_valid_time: 3600
-  become: true
-  when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
-
 - name: "(Debian) Get Gitlab repository installation script"
   ansible.builtin.get_url:
     url: https://packages.gitlab.com/install/repositories/runner/{{ gitlab_runner_package_name }}/script.deb.sh
@@ -14,8 +8,6 @@
 
 - name: "(Debian) Install Gitlab repository"
   ansible.builtin.command: bash /tmp/gitlab-runner.script.deb.sh
-  args:
-    creates: /etc/apt/sources.list.d/runner_{{ gitlab_runner_package_name }}.list
   become: true
   when: gitlab_runner_skip_package_repo_install is not defined or not gitlab_runner_skip_package_repo_install
 


### PR DESCRIPTION
This fixes https://github.com/riemers/ansible-gitlab-runner/issues/437 for Debian-family.

Instead of refreshing the APT package cache every time, run GitLab's repository install script every time. The script does an package cache refresh anyway and this way it is ensured that expired GPG keys get replaced.