### PR TITLE
fix: install gitlab-runner and its helper images in one apt transaction

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -63,18 +63,15 @@
     - ('gitlab-runner-helper-images' in ansible_facts.packages)
     - (gitlab_runner_package_version is undefined or gitlab_runner_package_version is version('17.7.0', '>='))
 
-- name: "(Debian) Install GitLab Runner Helpers"
+# One transaction: gitlab-runner strictly Depends on the matching
+# gitlab-runner-helper-images version, so installing them separately is
+# unsatisfiable in either order. The helper package exists only from 17.7.1
+# onward (#363, #370), hence the conditional list.
+- name: "(Debian) Install GitLab Runner and its helper images"
+  vars:
+    gitlab_runner_helper_supported: "{{ gitlab_runner_package_version is undefined or gitlab_runner_package_version is version('17.7.0', '>=') }}"
   ansible.builtin.apt:
-    name: "{{ gitlab_runner_helper_package }}"
-    state: "{{ gitlab_runner_package_state }}"
-    allow_change_held_packages: true
-    allow_downgrade: true
-  become: true
-  when: gitlab_runner_package_version is undefined or gitlab_runner_package_version is version('17.7.0', '>=')
-
-- name: "(Debian) Install GitLab Runner"
-  ansible.builtin.apt:
-    name: "{{ gitlab_runner_package }}"
+    name: "{{ [gitlab_runner_package] + ([gitlab_runner_helper_package] if gitlab_runner_helper_supported | bool else []) }}"
     state: "{{ gitlab_runner_package_state }}"
     allow_change_held_packages: true
     allow_downgrade: true


### PR DESCRIPTION
`gitlab-runner` strictly `Depends` on the matching `gitlab-runner-helper-images` version, but the role installs the two packages in separate apt transactions. Upgrading a pinned pair is therefore unsatisfiable — the installed runner still pins the old helper:

```
TASK [riemers.gitlab-runner : (Debian) Install GitLab Runner Helpers]
gitlab-runner : Depends: gitlab-runner-helper-images (= 19.2.1-1)
                but 19.2.2-1 is to be installed
E: Error, pkgProblemResolver::Resolve generated breaks
```

Installing the runner first fails the other way — the `held broken packages` error that #363 fixed by adding the helpers task. Each ordering breaks one path; naming both packages in a single apt call satisfies the pinned dependency in both.

### Change

One task instead of two. The helper package is appended to the list on exactly the condition that previously gated its own task, so pre-17.7.0 pins keep working (#370):

| `gitlab_runner_package_version` | apt `name` |
|---|---|
| undefined | `[gitlab-runner, gitlab-runner-helper-images]`, `state: latest` |
| `16.9.0-1` | `[gitlab-runner=16.9.0-1]` |
| `19.2.2-1` | both, pinned to `19.2.2-1` |

### Testing

`ansible-lint` clean (repo `profile: production`).

Reproduced in a clean `ubuntu:noble` container with the `19.2.1-1` pair installed and held: helpers alone → exit 100 with the error above; both in one transaction → exit 0.

Applied with this branch on two Ubuntu 24.04 hosts (three runner instances), upgrading `19.2.1-1` → `19.2.2-1`: `2 upgraded, 0 newly installed`, `failed=0` on both hosts, all three runners re-registered on the new version. The same upgrade with `v2.1.2` failed at the resolver on both hosts beforehand.
