### PR TITLE
fix: by_config_toml: duplicate [runners.feature_flags] when an unmanaged

### DIFF
--- a/tasks/update-config-runner.yml
+++ b/tasks/update-config-runner.yml
@@ -929,6 +929,18 @@
     - restart_gitlab_runner_macos
 
 #### [runners.feature_flags] section #####
+- name: "Remove unmanaged feature flag section {{ runn_name_prefix }}"
+  ansible.builtin.replace:
+    path: "{{ temp_runner_config.path }}"
+    regexp: '(?m)(?<!# BEGIN runners\.feature_flags\n)^[ \t]*\[runners\.feature_flags\][ \t]*(?:#.*)?(?:\n|\Z)(?:(?![ \t]*\[)(?:[^\n]+(?:\n|\Z)|\n))*'
+    replace: ""
+  when: gitlab_runner.feature_flags is defined
+  check_mode: false
+  no_log: "{{ gitlab_runner_no_log_secrets | default(false) }}"
+  notify:
+    - restart_gitlab_runner
+    - restart_gitlab_runner_macos
+
 - name: "Set feature flag options {{ runn_name_prefix }}"
   ansible.builtin.blockinfile:
     path: "{{ temp_runner_config.path }}"


### PR DESCRIPTION
Fix and closed https://github.com/riemers/ansible-gitlab-runner/issues/444

section already exists

### Log before fix
```
TASK [riemers.ansible-gitlab-runner : Set feature flag options conf[11/14]: runner[1/2]:] ******************************************************
changed: [runner2.int.frogg.it]

(...)

TASK [riemers.ansible-gitlab-runner : Assemble new config.toml] ********************************************************************************
fatal: [runner2.int.frogg.it]: FAILED! => {"changed": false, "msg": "failed to validate: rc:1 error:Runtime platform                                  \u001b[0;m  arch\u001b[0;m=amd64 os\u001b[0;m=linux pid\u001b[0;m=991672 revision\u001b[0;m=6821ab40 version\u001b[0;m=19.2.3\nRunning in system-mode.                           \u001b[0;m \n                                                  \u001b[0;m \n\u001b[31;1mFATAL: decoding configuration file: toml: line 87 (last key \"runners\"): Key 'runners.feature_flags' has already been defined.\u001b[0;m \n"}
```

### Log after fix
```
TASK [riemers.ansible-gitlab-runner : Remove unmanaged feature flag section conf[12/14]: runner[2/2]:] *****************************************
changed: [runner2.int.frogg.it]

TASK [riemers.ansible-gitlab-runner : Set feature flag options conf[12/14]: runner[2/2]:] ******************************************************
changed: [runner2.int.frogg.it]

(...)

TASK [riemers.ansible-gitlab-runner : Assemble new config.toml] ********************************************************************************
changed: [runner2.int.frogg.it]
```
The generated file `config.toml` is correct.

I didn't write the tests because I'm not comfortable with molecules.
But tested on my today's deploy.